### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+## 0.2.1
+
+### Fixes
+
+* Create link destination directories if they do not exist.
+
+### Feature updates
+
+* Add task to set environment variables for the executing user.
+
 ## 0.2.0
 
 ### Feature updates

--- a/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
+++ b/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Cnct.Core.Configuration;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class EnvironmentVariableSpecificationTests
+    {
+        [Fact]
+        public void CanDeserializeEnvironmentVariableSpec()
+        {
+            const string expectedVarName = "someVariable";
+            const string expectedValue = "someValue";
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "environmentVariable",
+                ["name"] = expectedVarName,
+                ["value"] = expectedValue,
+            });
+
+            ICnctActionSpec spec = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+
+            EnvironmentVariableTaskSpecification envVariableSpec =
+                Assert.IsType<EnvironmentVariableTaskSpecification>(spec);
+            Assert.Equal(expectedVarName, envVariableSpec.Name);
+            Assert.Equal(expectedValue, envVariableSpec.Value);
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
@@ -3,12 +3,32 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Cnct.Core.Configuration;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Cnct.Core.Tests
 {
     public class LinkTaskSpecificationTests
     {
+        [Fact]
+        public void CanDeserializeLinkTaskSpec()
+        {
+            var expectedLinks = new Dictionary<string, string>
+            {
+                ["file"] = "destination",
+            };
+
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "link",
+                ["links"] = expectedLinks,
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<LinkTaskSpecification>(specInterface);
+            Assert.Equal(expectedLinks.Count, spec.Links.Count);
+        }
+
         [Fact]
         public void NullLinkPath()
         {

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -11,7 +11,7 @@ namespace Cnct.Core.Tests
         [Theory]
         [InlineData(ShellTaskSpecification.ShellType.PowerShell, "PowerShell")]
         [InlineData(ShellTaskSpecification.ShellType.PowerShell, "powershell")]
-        public void CanDeserializeAllPlatformLinks(
+        public void CanDeserializeShellType(
             ShellTaskSpecification.ShellType expectedShellType,
             string shellTypeStr)
         {
@@ -24,7 +24,8 @@ namespace Cnct.Core.Tests
                 ["os"] = "windows",
             });
 
-            var spec = JsonConvert.DeserializeObject<ShellTaskSpecification>(json);
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
             Assert.Equal(expectedShellType, spec.Shell);
             Assert.Equal(command, spec.Command);
             Assert.Equal(PlatformType.Windows, spec.PlatformType.Single());

--- a/Cnct/Cnct.Core/Cnct.Core.csproj
+++ b/Cnct/Cnct.Core/Cnct.Core.csproj
@@ -9,18 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="Microsoft.PowerShell.SDK" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
-    <PackageReference Include="System.Management.Automation" Version="7.2.1" />
+	<PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Management.Automation" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cnct.SourceGeneration\Cnct.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/Cnct/Cnct.Core/Configuration/CnctActionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionConverter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Cnct.Core.Configuration
 {
-    public class CnctActionConverter : JsonConverter<ICnctActionSpec>
+    public partial class CnctActionConverter : JsonConverter<ICnctActionSpec>
     {
         public override bool CanRead => true;
 
@@ -18,13 +18,7 @@ namespace Cnct.Core.Configuration
             JsonSerializer serializer)
         {
             JObject jsonObject = JObject.Load(reader);
-            ICnctActionSpec spec = jsonObject["actionType"].Value<string>() switch
-            {
-                "link" => new LinkTaskSpecification(),
-                "shell" => new ShellTaskSpecification(),
-                _ => throw new NotImplementedException(),
-            };
-
+            ICnctActionSpec spec = GetActionSpecFromType(jsonObject["actionType"].Value<string>());
             if (spec != null)
             {
                 serializer?.Populate(jsonObject.CreateReader(), spec);

--- a/Cnct/Cnct.Core/Configuration/CnctActionTypeAttribute.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionTypeAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Cnct.Core.Configuration
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class CnctActionTypeAttribute : Attribute
+    {
+        public string ActionType { get; set; }
+
+        public CnctActionTypeAttribute(string actionType)
+        {
+            this.ActionType = actionType;
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cnct.Core.Tasks.EnvironmentVariable;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    [CnctActionType("environmentVariable")]
+    public partial class EnvironmentVariableTaskSpecification : ICnctActionSpec
+    {
+        [JsonRequired]
+        public string Name { get; set; }
+
+        [JsonRequired]
+        public string Value { get; set; }
+
+        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        {
+            var envVariableTask = new EnvironmentVariableTask(logger, this.Name, this.Value);
+            await envVariableTask.ExecuteAsync();
+        }
+
+        public void Validate()
+        {
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -8,10 +8,9 @@ using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {
-    public sealed class LinkTaskSpecification : ICnctActionSpec
+    [CnctActionType("link")]
+    public sealed partial class LinkTaskSpecification : ICnctActionSpec
     {
-        public string ActionType => "link";
-
         [JsonConverter(typeof(LinkSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Links { get; set; }
 

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -7,10 +7,9 @@ using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {
-    public class ShellTaskSpecification : ICnctActionSpec
+    [CnctActionType("shell")]
+    public partial class ShellTaskSpecification : ICnctActionSpec
     {
-        public string ActionType { get; } = "shell";
-
         [JsonRequired]
         public ShellType Shell { get; set; }
 

--- a/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
+++ b/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Cnct.Core.Tasks.EnvironmentVariable
+{
+    internal class EnvironmentVariableTask : CnctTaskBase
+    {
+        public string Name { get; set; }
+
+        public string Value { get; set; }
+
+        public EnvironmentVariableTask(ILogger logger, string name, string value)
+            : base(logger)
+        {
+            this.Name = name;
+            this.Value = value;
+        }
+
+        public override Task ExecuteAsync()
+        {
+            Environment.SetEnvironmentVariable(this.Name, this.Value, EnvironmentVariableTarget.User);
+            this.Logger.LogInformation($"Set environment variable '{this.Name}' to '{this.Value}'.");
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/LinkTask.cs
@@ -56,6 +56,12 @@ namespace Cnct.Core.Tasks
                 Directory.Delete(linkPath);
             }
 
+            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(Path.DirectorySeparatorChar)];
+            if (!Directory.Exists(destinationLinkDirectory))
+            {
+                Directory.CreateDirectory(destinationLinkDirectory);
+            }
+
             switch (Platform.CurrentPlatform)
             {
                 case PlatformType.Windows:

--- a/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
+++ b/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cnct</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>bgold09</Authors>
     <Description>Cnct is a cross-platform command-line tool that aims to make bootstrapping your developer environment easier. This is accomplished by providing a set of common operations (e.g. creating symlinks) that can be expressed in a simple configuration.</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -20,15 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Cnct/Cnct.SourceGeneration/Cnct.SourceGeneration.csproj
+++ b/Cnct/Cnct.SourceGeneration/Cnct.SourceGeneration.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
+++ b/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Cnct.SourceGeneration
+{
+    [Generator]
+    public class CnctTaskSpecificationGenerator : ISourceGenerator
+    {
+        private const string NamespaceCnctCoreConfiguration = "Cnct.Core.Configuration";
+
+        private const string CnctActionSpecInterfaceName = "ICnctActionSpec";
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            const string CnctActionConverterClassName = "CnctActionConverter";
+            const string AttributeName = "CnctActionType";
+            var syntaxReceiver = context.SyntaxReceiver as ActionSpecSyntaxReceiver;
+            var actionTypeToClassNameMap = new List<(string actionType, string className)>();
+            foreach (ClassDeclarationSyntax cds in syntaxReceiver.ClassesToAugment)
+            {
+                AttributeSyntax result = cds.AttributeLists
+                    .SelectMany(attributeList => attributeList.Attributes)
+                    .SingleOrDefault(a => ((IdentifierNameSyntax)a.Name).Identifier.ValueText == AttributeName);
+
+                if (result != null)
+                {
+                    AttributeArgumentSyntax attributeArgument = result.ArgumentList.Arguments.Single();
+                    string value = result.ArgumentList.Arguments.Single().Expression.GetText().ToString();
+                    value = value.Substring(1, value.Length - 2);
+
+                    string className = cds.Identifier.ValueText;
+                    this.AddActionSpecGeneratedSource(context, value, className);
+                    actionTypeToClassNameMap.Add((value, className));
+                }
+            }
+
+            StringBuilder actionConverterSourceBuilder = new(@$"using System;
+
+namespace {NamespaceCnctCoreConfiguration}
+{{
+    public partial class {CnctActionConverterClassName}
+    {{
+        private static {CnctActionSpecInterfaceName} GetActionSpecFromType(string actionType)
+        {{
+            return actionType switch
+            {{
+");
+
+            foreach (var (actionType, className) in actionTypeToClassNameMap)
+            {
+                actionConverterSourceBuilder.AppendLine(
+                    @$"               ""{actionType}"" => new {className}(),");
+            }
+
+            actionConverterSourceBuilder.AppendLine(@"                _ => throw new NotImplementedException(),
+            };
+        }
+    }
+}");
+
+            context.AddSource(
+                $"{CnctActionConverterClassName}.g.cs",
+                SourceText.From(actionConverterSourceBuilder.ToString(), Encoding.UTF8));
+        }
+
+        public void Initialize(GeneratorInitializationContext context)
+        {
+            context.RegisterForSyntaxNotifications(() => new ActionSpecSyntaxReceiver());
+        }
+
+        private void AddActionSpecGeneratedSource(
+            GeneratorExecutionContext context,
+            string actionType,
+            string className)
+        {
+            string source = @$"
+namespace {NamespaceCnctCoreConfiguration}
+{{
+    public partial class {className}
+    {{
+        public string ActionType {{ get; }} = ""{actionType}"";
+    }}
+}}
+";
+
+            context.AddSource($"{className}.g.cs", SourceText.From(source, Encoding.UTF8));
+        }
+
+        private class ActionSpecSyntaxReceiver : ISyntaxReceiver
+        {
+            public ISet<ClassDeclarationSyntax> ClassesToAugment { get; } = new HashSet<ClassDeclarationSyntax>();
+
+            public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+            {
+                if (syntaxNode is ClassDeclarationSyntax cds &&
+                        cds.BaseList?.Types
+                            .Where(t => t.Type.IsKind(SyntaxKind.IdentifierName))
+                            .Select(t => t.Type)
+                            .Cast<IdentifierNameSyntax>()
+                            .Any(t => t.Identifier.ValueText == CnctActionSpecInterfaceName) == true)
+                {
+                    this.ClassesToAugment.Add(cds);
+                }
+            }
+        }
+    }
+}

--- a/Cnct/Cnct.sln
+++ b/Cnct/Cnct.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.202
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cnct.Core", "Cnct.Core\Cnct.Core.csproj", "{2278AC36-CCDA-4350-9A72-7C3011B8EA32}"
 EndProject
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cnct.SourceGeneration", "Cnct.SourceGeneration\Cnct.SourceGeneration.csproj", "{162505E8-9485-4231-A2F9-A18514671993}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +34,10 @@ Global
 		{D2236735-B1EF-4EC1-8982-E3A10E5E92CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2236735-B1EF-4EC1-8982-E3A10E5E92CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2236735-B1EF-4EC1-8982-E3A10E5E92CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{162505E8-9485-4231-A2F9-A18514671993}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{162505E8-9485-4231-A2F9-A18514671993}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{162505E8-9485-4231-A2F9-A18514671993}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{162505E8-9485-4231-A2F9-A18514671993}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Cnct/Directory.Packages.props
+++ b/Cnct/Directory.Packages.props
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
+    <PackageVersion Include="System.Management.Automation" Version="7.2.1" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+</Project>

--- a/Cnct/NuGet.config
+++ b/Cnct/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -18,6 +18,9 @@
                     },
                     {
                         "$ref": "#/definitions/LinkAction"
+                    },
+                    {
+                        "$ref": "#/definitions/EnvironmentVariableAction"
                     }
                 ]
             }
@@ -153,6 +156,36 @@
                                     }
                                 ]
                             }
+                        }
+                    }
+                }
+            ]
+        },
+        "EnvironmentVariableAction": {
+            "description": "Set an environment variable.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "environmentVariable"
+                            ]
+                        },
+                        "name": {
+                            "description": "The name of the environment variable to set.",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the environment variable to set.",
+                            "type": "string"
                         }
                     }
                 }


### PR DESCRIPTION
* feat: add task to set environment variables for the executing user (#34)

* build: source generator for action specs (#35)

* Action specs declare a type discriminator that is used when deserializing a JSON configuration.
* This type discriminator must match what's used in the custom JSOM converter so that it can discover which type string matches which concrete class. This is tedious and error prone when adding new action types.
* Use C# source generators that look for types that implement ICnctActionSpec and have the CnctActionType attribute, and generate the required partial class and mappings for the JSON converter to use.

* build: use nuget central package management (#38)

* fix: create link destination directory if it does not exist (#39)

Fixes #22

* fix: release version 0.2.1