### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/actions-main.yml
+++ b/.github/workflows/actions-main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        global-json-file: global.json
         source-url: https://nuget.pkg.github.com/${{github.repository_owner}}/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/actions-main.yml
+++ b/.github/workflows/actions-main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
         source-url: https://nuget.pkg.github.com/${{github.repository_owner}}/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/actions-main.yml
+++ b/.github/workflows/actions-main.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ${{matrix.image}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         global-json-file: global.json
         source-url: https://nuget.pkg.github.com/${{github.repository_owner}}/index.json

--- a/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
+++ b/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Cnct/Cnct.Core/Cnct.Core.csproj
+++ b/Cnct/Cnct.Core/Cnct.Core.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cnct.Core</AssemblyName>
     <RootNamespace>Cnct.Core</RootNamespace>
     <LangVersion>8.0</LangVersion>

--- a/Cnct/Cnct.Core/Configuration/Platform.cs
+++ b/Cnct/Cnct.Core/Configuration/Platform.cs
@@ -42,17 +42,17 @@ namespace Cnct.Core.Configuration
 
         private static PlatformType GetCurrentPlatformType()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return PlatformType.Windows;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return PlatformType.Linux;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return PlatformType.OSX;
             }

--- a/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
+++ b/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cnct</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/Cnct/Directory.Build.props
+++ b/Cnct/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Cnct/Directory.Packages.props
+++ b/Cnct/Directory.Packages.props
@@ -6,13 +6,13 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
-    <PackageVersion Include="System.Management.Automation" Version="7.2.1" />
+    <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.14" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
- Upgrade the repo to .NET 8.
- Upgrade some packages to get rid of `NETSDK1206` warning.
-  Simplify determination of operating system type.