### PR TITLE
fix: align version of Microsoft.PowerShell.SDK with System.Management.Automation

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,6 @@
         "line_length": 104,
         "code_blocks": false
     },
-    "no-duplicate-header": false,
+    "no-duplicate-heading": false,
     "ul-start-left": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+* Align version of `Microsoft.PowerShell.SDK` with `System.Management.Automation`
+
 ## 0.3.1
 
 ### Feature updates

--- a/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
+++ b/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
@@ -27,6 +27,7 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <EmbeddedResource Include="..\Directory.Packages.props" />
   </ItemGroup>
 
 </Project>

--- a/Cnct/Cnct.Core.Tests/PackageVersionsTests.cs
+++ b/Cnct/Cnct.Core.Tests/PackageVersionsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class PackageVersionsTests
+    {
+        [Fact]
+        public void PowerShellPackages_ShouldHaveSameVersion()
+        {
+            var assembly = typeof(PackageVersionsTests).Assembly;
+            string resourceName = assembly.GetManifestResourceNames()
+                .FirstOrDefault(n => n.EndsWith("Directory.Packages.props", StringComparison.OrdinalIgnoreCase));
+
+            Assert.False(
+                string.IsNullOrEmpty(resourceName),
+                "Embedded resource 'Directory.Packages.props' not found in test assembly resources.");
+
+            using Stream stream = assembly.GetManifestResourceStream(resourceName);
+            Assert.NotNull(stream);
+
+            var doc = XDocument.Load(stream);
+            XNamespace ns = doc.Root.GetDefaultNamespace();
+
+            var packageVersions = doc.Descendants("PackageVersion")
+                .Select(e => new
+                {
+                    Include = (string)e.Attribute("Include"),
+                    Version = (string)e.Attribute("Version"),
+                })
+                .Where(x => x.Include == "Microsoft.PowerShell.SDK" || x.Include == "System.Management.Automation")
+                .ToList();
+
+            Assert.Contains(packageVersions, p => p.Include == "Microsoft.PowerShell.SDK");
+            Assert.Contains(packageVersions, p => p.Include == "System.Management.Automation");
+
+            string powershellSdkPackageVersion =
+                packageVersions.Single(p => p.Include == "Microsoft.PowerShell.SDK").Version;
+            string systemManagementAutomationVersion =
+                packageVersions.Single(p => p.Include == "System.Management.Automation").Version;
+
+            Assert.Equal(powershellSdkPackageVersion, systemManagementAutomationVersion);
+        }
+    }
+}

--- a/Cnct/Directory.Packages.props
+++ b/Cnct/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.5.2" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
- Packages`Microsoft.PowerShell.SDK` and `System.Management.Automation`
  should be on the same versions. This ensures that core cmdlets are
  loaded correctly when the "powershell" task is invoked.
- Add test coverage to enforce the package versions are aligned.