### PR TITLE
Migrate tasks to System.IO.Abstractions for IFileSystem injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+* Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem operations, enabling full unit test coverage without real disk I/O.
+
 ## 0.4.0
 
 ### Feature updates

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
@@ -113,16 +114,16 @@ namespace Cnct.Core.Tests
             string relativeDest = Path.Combine("dev", "repo-a");
             string expectedDest = Path.Combine(configRoot, relativeDest);
 
+            var mockFileSystem = new MockFileSystem();
             var mockRunner = new Mock<IGitRunner>();
             mockRunner.Setup(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
-            var logger = Mock.Of<ILogger>();
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
                 Repos = new Dictionary<string, string> { [url] = relativeDest },
             };
 
-            await spec.ExecuteAsync(logger, configRoot);
+            await spec.ExecuteAsync(Mock.Of<ILogger>(), configRoot);
 
             mockRunner.Verify(
                 r => r.CloneAsync(url, expectedDest),
@@ -135,10 +136,11 @@ namespace Cnct.Core.Tests
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "repo-a");
             const string url = "https://example.com/org/repo-a";
 
+            var mockFileSystem = new MockFileSystem();
             var mockRunner = new Mock<IGitRunner>();
             mockRunner.Setup(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
                 Repos = new Dictionary<string, string> { [url] = dest },
             };
@@ -153,83 +155,70 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_PullsWhenDotGitDirectoryExists()
         {
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(Path.Combine(dest, ".git"));
-            try
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.Combine(dest, ".git"));
+
+            const string url = "https://example.com/org/repo-a";
+            var mockRunner = new Mock<IGitRunner>();
+            mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
-                const string url = "https://example.com/org/repo-a";
-                var mockRunner = new Mock<IGitRunner>();
-                mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+                Repos = new Dictionary<string, string> { [url] = dest },
+            };
 
-                var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
-                {
-                    Repos = new Dictionary<string, string> { [url] = dest },
-                };
+            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
 
-                await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-                mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
-                mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            }
-            finally
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+            mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
+            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_PullsWhenDotGitFileExists()
         {
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(dest);
-            File.WriteAllText(Path.Combine(dest, ".git"), "gitdir: ../.git/worktrees/worktree1");
-            try
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(dest);
+            mockFileSystem.File.WriteAllText(
+                mockFileSystem.Path.Combine(dest, ".git"),
+                "gitdir: ../.git/worktrees/worktree1");
+
+            const string url = "https://example.com/org/repo-a";
+            var mockRunner = new Mock<IGitRunner>();
+            mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
-                const string url = "https://example.com/org/repo-a";
-                var mockRunner = new Mock<IGitRunner>();
-                mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+                Repos = new Dictionary<string, string> { [url] = dest },
+            };
 
-                var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
-                {
-                    Repos = new Dictionary<string, string> { [url] = dest },
-                };
+            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
 
-                await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-                mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
-                mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            }
-            finally
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+            mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
+            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_LogsWarningWhenDestExistsButIsNotGitRepo()
         {
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(dest);
-            try
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(dest);
+
+            const string url = "https://example.com/org/repo-a";
+            var mockRunner = new Mock<IGitRunner>();
+            var logger = new Mock<ILogger>();
+
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
-                const string url = "https://example.com/org/repo-a";
-                var mockRunner = new Mock<IGitRunner>();
-                var logger = new Mock<ILogger>();
+                Repos = new Dictionary<string, string> { [url] = dest },
+            };
 
-                var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
-                {
-                    Repos = new Dictionary<string, string> { [url] = dest },
-                };
+            await spec.ExecuteAsync(logger.Object, Path.GetTempPath());
 
-                await spec.ExecuteAsync(logger.Object, Path.GetTempPath());
-
-                logger.Verify(l => l.LogWarning(It.Is<string>(s => s.Contains(dest))), Times.Once);
-                mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-                mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
-            }
-            finally
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+            logger.Verify(l => l.LogWarning(It.Is<string>(s => s.Contains(dest))), Times.Once);
+            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
+++ b/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Moq;
@@ -82,13 +83,14 @@ namespace Cnct.Core.Tests
             var logger = new Mock<ILogger>();
             logger.Setup(l => l.LogWarning(It.IsAny<string>()));
 
-            var spec = new LinkExpandTaskSpecification
+            // Source dir doesn't exist in the mock filesystem → task logs a warning
+            var mockFileSystem = new MockFileSystem();
+            var spec = new LinkExpandTaskSpecification(mockFileSystem)
             {
                 Source = relativeSource,
                 Target = "~/some/target",
             };
 
-            // Source resolves to <configRoot>/skills which doesn't exist — logs warning, doesn't throw
             await spec.ExecuteAsync(logger.Object, configRoot);
 
             logger.Verify(

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Newtonsoft.Json;
@@ -10,15 +10,23 @@ namespace Cnct.Core.Configuration
     [CnctActionType("cloneGitRepository")]
     public sealed partial class CloneGitRepositoryTaskSpecification : ICnctActionSpec
     {
+        private readonly IFileSystem fileSystem;
         private readonly IGitRunner gitRunner;
 
         public CloneGitRepositoryTaskSpecification()
         {
+            this.fileSystem = new FileSystem();
         }
 
         public CloneGitRepositoryTaskSpecification(IGitRunner gitRunner)
+            : this(gitRunner, new FileSystem())
+        {
+        }
+
+        public CloneGitRepositoryTaskSpecification(IGitRunner gitRunner, IFileSystem fileSystem)
         {
             this.gitRunner = gitRunner;
+            this.fileSystem = fileSystem;
         }
 
         [JsonProperty("repos")]
@@ -51,15 +59,20 @@ namespace Cnct.Core.Configuration
             foreach (var kvp in this.Repos)
             {
                 string dest = kvp.Value.NormalizePath();
-                if (!Path.IsPathRooted(dest))
+                if (!this.fileSystem.Path.IsPathRooted(dest))
                 {
-                    dest = Path.Combine(configDirectoryRoot, dest);
+                    dest = this.fileSystem.Path.Combine(configDirectoryRoot, dest);
                 }
 
                 normalizedRepos[kvp.Key] = dest;
             }
 
-            var cloneTask = new CloneGitRepositoryTask(logger, normalizedRepos, this.gitRunner ?? new ProcessGitRunner(logger));
+            var cloneTask = new CloneGitRepositoryTask(
+                logger,
+                normalizedRepos,
+                this.gitRunner ?? new ProcessGitRunner(logger),
+                this.fileSystem);
+
             return cloneTask.ExecuteAsync();
         }
     }

--- a/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
@@ -1,23 +1,31 @@
 ﻿using System;
 using System.IO;
+using System.IO.Abstractions;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {
     public class CnctConfigurationParser
     {
+        private readonly IFileSystem fileSystem;
         private readonly ILogger logger;
 
         public CnctConfigurationParser(ILogger logger)
+            : this(logger, new FileSystem())
+        {
+        }
+
+        public CnctConfigurationParser(ILogger logger, IFileSystem fileSystem)
         {
             this.logger = logger;
+            this.fileSystem = fileSystem;
         }
 
         public CnctConfig Parse(string configFile)
         {
             configFile = configFile == null
-                ? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json"
-                : Path.GetFullPath(configFile);
+                ? $"{this.fileSystem.Directory.GetCurrentDirectory()}{this.fileSystem.Path.DirectorySeparatorChar}cnct.json"
+                : this.fileSystem.Path.GetFullPath(configFile);
 
             if (string.IsNullOrWhiteSpace(configFile))
             {
@@ -26,17 +34,17 @@ namespace Cnct.Core.Configuration
                     nameof(configFile));
             }
 
-            if (!File.Exists(configFile))
+            if (!this.fileSystem.File.Exists(configFile))
             {
                 throw new FileNotFoundException("The config file does not exist.", configFile);
             }
 
             try
             {
-                string json = File.ReadAllText(configFile);
+                string json = this.fileSystem.File.ReadAllText(configFile);
                 CnctConfig config = JsonConvert.DeserializeObject<CnctConfig>(json);
                 config.Logger = this.logger;
-                config.ConfigRootDirectory = Path.GetDirectoryName(configFile);
+                config.ConfigRootDirectory = this.fileSystem.Path.GetDirectoryName(configFile);
 
                 return config;
             }

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -11,18 +11,25 @@ namespace Cnct.Core.Configuration
     public partial class CopyTaskSpecification : ICnctActionSpec
     {
         private readonly IFileManagement fileManagement;
+        private readonly IFileSystem fileSystem;
 
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Files { get; set; }
 
         public CopyTaskSpecification(IFileManagement fileManagement)
+            : this(fileManagement, new FileSystem())
+        {
+        }
+
+        public CopyTaskSpecification(IFileManagement fileManagement, IFileSystem fileSystem)
         {
             this.fileManagement = fileManagement;
+            this.fileSystem = fileSystem;
         }
 
         public CopyTaskSpecification()
+            : this(new FileManagement(), new FileSystem())
         {
-            this.fileManagement = new FileManagement();
         }
 
         public void Validate()
@@ -37,7 +44,7 @@ namespace Cnct.Core.Configuration
         {
             var copyTask = new CopyTask(
                 logger,
-                new FileSystem(),
+                this.fileSystem,
                 this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Files));
 
             await copyTask.ExecuteAsync();

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -1,5 +1,5 @@
 using System;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Newtonsoft.Json;
@@ -9,6 +9,18 @@ namespace Cnct.Core.Configuration
     [CnctActionType("linkExpand")]
     public sealed partial class LinkExpandTaskSpecification : ICnctActionSpec
     {
+        private readonly IFileSystem fileSystem;
+
+        public LinkExpandTaskSpecification()
+        {
+            this.fileSystem = new FileSystem();
+        }
+
+        public LinkExpandTaskSpecification(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
         [JsonProperty("source")]
         public string Source { get; set; }
 
@@ -31,13 +43,13 @@ namespace Cnct.Core.Configuration
         public Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             string source = this.Source.NormalizePath();
-            if (!Path.IsPathRooted(source))
+            if (!this.fileSystem.Path.IsPathRooted(source))
             {
-                source = Path.Combine(configDirectoryRoot, source);
+                source = this.fileSystem.Path.Combine(configDirectoryRoot, source);
             }
 
             string target = this.Target.NormalizePath();
-            var linkExpandTask = new LinkExpandTask(logger, source, target);
+            var linkExpandTask = new LinkExpandTask(logger, source, target, this.fileSystem);
             return linkExpandTask.ExecuteAsync();
         }
     }

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Newtonsoft.Json;
@@ -10,15 +11,22 @@ namespace Cnct.Core.Configuration
     public sealed partial class LinkTaskSpecification : ICnctActionSpec
     {
         private readonly IFileManagement fileManagement;
+        private readonly IFileSystem fileSystem;
 
         public LinkTaskSpecification(IFileManagement fileManagement)
+            : this(fileManagement, new FileSystem())
+        {
+        }
+
+        public LinkTaskSpecification(IFileManagement fileManagement, IFileSystem fileSystem)
         {
             this.fileManagement = fileManagement;
+            this.fileSystem = fileSystem;
         }
 
         public LinkTaskSpecification()
+            : this(new FileManagement(), new FileSystem())
         {
-            this.fileManagement = new FileManagement();
         }
 
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
@@ -35,7 +43,9 @@ namespace Cnct.Core.Configuration
         public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var linkTask = new LinkTask(
-                logger, this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links));
+                logger,
+                this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links),
+                this.fileSystem);
 
             await linkTask.ExecuteAsync();
         }

--- a/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
@@ -1,24 +1,26 @@
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 
 namespace Cnct.Core.Tasks
 {
     internal class CloneGitRepositoryTask : CnctTaskBase
     {
+        private readonly IFileSystem fileSystem;
         private readonly IReadOnlyDictionary<string, string> repos;
         private readonly IGitRunner gitRunner;
 
-        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos)
-            : this(logger, repos, new ProcessGitRunner(logger))
+        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos, IGitRunner gitRunner)
+            : this(logger, repos, gitRunner, new FileSystem())
         {
         }
 
-        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos, IGitRunner gitRunner)
+        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos, IGitRunner gitRunner, IFileSystem fileSystem)
             : base(logger)
         {
             this.repos = repos;
             this.gitRunner = gitRunner;
+            this.fileSystem = fileSystem;
         }
 
         public override async Task ExecuteAsync()
@@ -27,24 +29,24 @@ namespace Cnct.Core.Tasks
             {
                 string url = kvp.Key;
                 string dest = kvp.Value;
-                string gitPath = Path.Combine(dest, ".git");
+                string gitPath = this.fileSystem.Path.Combine(dest, ".git");
 
-                if (File.Exists(gitPath) || Directory.Exists(gitPath))
+                if (this.fileSystem.File.Exists(gitPath) || this.fileSystem.Directory.Exists(gitPath))
                 {
                     this.Logger.LogInformation($"  [GIT] Pulling latest changes in '{dest}'");
                     await this.gitRunner.PullAsync(dest);
                 }
-                else if (Directory.Exists(dest))
+                else if (this.fileSystem.Directory.Exists(dest))
                 {
                     this.Logger.LogWarning($"Directory '{dest}' exists but is not a git repository. Skipping.");
                 }
                 else
                 {
                     this.Logger.LogInformation($"  [GIT] Cloning '{url}' to '{dest}'");
-                    string parent = Path.GetDirectoryName(dest);
-                    if (!string.IsNullOrEmpty(parent) && !Directory.Exists(parent))
+                    string parent = this.fileSystem.Path.GetDirectoryName(dest);
+                    if (!string.IsNullOrEmpty(parent) && !this.fileSystem.Directory.Exists(parent))
                     {
-                        Directory.CreateDirectory(parent);
+                        this.fileSystem.Directory.CreateDirectory(parent);
                     }
 
                     await this.gitRunner.CloneAsync(url, dest);

--- a/Cnct/Cnct.Core/Tasks/LinkExpandTask.cs
+++ b/Cnct/Cnct.Core/Tasks/LinkExpandTask.cs
@@ -1,38 +1,45 @@
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 
 namespace Cnct.Core.Tasks
 {
     internal class LinkExpandTask : CnctTaskBase
     {
+        private readonly IFileSystem fileSystem;
         private readonly string source;
         private readonly string target;
 
         public LinkExpandTask(ILogger logger, string source, string target)
+            : this(logger, source, target, new FileSystem())
+        {
+        }
+
+        public LinkExpandTask(ILogger logger, string source, string target, IFileSystem fileSystem)
             : base(logger)
         {
             this.source = source;
             this.target = target;
+            this.fileSystem = fileSystem;
         }
 
         public override Task ExecuteAsync()
         {
-            if (!Directory.Exists(this.source))
+            if (!this.fileSystem.Directory.Exists(this.source))
             {
                 this.Logger.LogWarning($"Source directory '{this.source}' does not exist.");
                 return Task.FromResult(0);
             }
 
             var links = new Dictionary<string, IEnumerable<string>>();
-            foreach (string subdirectory in Directory.EnumerateDirectories(this.source))
+            foreach (string subdirectory in this.fileSystem.Directory.EnumerateDirectories(this.source))
             {
-                string name = Path.GetFileName(subdirectory);
-                string linkPath = Path.Combine(this.target, name);
+                string name = this.fileSystem.Path.GetFileName(subdirectory);
+                string linkPath = this.fileSystem.Path.Combine(this.target, name);
                 links[subdirectory] = new[] { linkPath };
             }
 
-            var linkTask = new LinkTask(this.Logger, links);
+            var linkTask = new LinkTask(this.Logger, links, this.fileSystem);
             return linkTask.ExecuteAsync();
         }
     }

--- a/Cnct/Cnct.Core/Tasks/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/LinkTask.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
@@ -9,12 +9,19 @@ namespace Cnct.Core.Tasks
 {
     internal class LinkTask : CnctTaskBase
     {
+        private readonly IFileSystem fileSystem;
         private readonly IDictionary<string, IEnumerable<string>> links;
 
         public LinkTask(ILogger logger, IDictionary<string, IEnumerable<string>> links)
+            : this(logger, links, new FileSystem())
+        {
+        }
+
+        public LinkTask(ILogger logger, IDictionary<string, IEnumerable<string>> links, IFileSystem fileSystem)
             : base(logger)
         {
             this.links = links;
+            this.fileSystem = fileSystem;
         }
 
         public override Task ExecuteAsync()
@@ -27,11 +34,11 @@ namespace Cnct.Core.Tasks
                 foreach (string link in destinationLinks)
                 {
                     this.Logger.LogInformation($"  [LINK] {target} -> {link}");
-                    if (File.Exists(target))
+                    if (this.fileSystem.File.Exists(target))
                     {
                         this.CreateLink(link, target, LinkType.File);
                     }
-                    else if (Directory.Exists(target))
+                    else if (this.fileSystem.Directory.Exists(target))
                     {
                         this.CreateLink(link, target, LinkType.Directory);
                     }
@@ -47,19 +54,19 @@ namespace Cnct.Core.Tasks
 
         private void CreateLink(string linkPath, string targetPath, LinkType linkType)
         {
-            if (File.Exists(linkPath))
+            if (this.fileSystem.File.Exists(linkPath))
             {
-                File.Delete(linkPath);
+                this.fileSystem.File.Delete(linkPath);
             }
-            else if (Directory.Exists(linkPath))
+            else if (this.fileSystem.Directory.Exists(linkPath))
             {
-                Directory.Delete(linkPath);
+                this.fileSystem.Directory.Delete(linkPath);
             }
 
-            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(Path.DirectorySeparatorChar)];
-            if (!Directory.Exists(destinationLinkDirectory))
+            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(this.fileSystem.Path.DirectorySeparatorChar)];
+            if (!this.fileSystem.Directory.Exists(destinationLinkDirectory))
             {
-                Directory.CreateDirectory(destinationLinkDirectory);
+                this.fileSystem.Directory.CreateDirectory(destinationLinkDirectory);
             }
 
             switch (Platform.CurrentPlatform)

--- a/Cnct/Directory.Packages.props
+++ b/Cnct/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.15" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.15" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
All tasks (LinkTask, LinkExpandTask, CloneGitRepositoryTask) and their specifications now accept IFileSystem, replacing direct System.IO calls. CnctConfigurationParser and CopyTaskSpecification/LinkTaskSpecification also updated. Tests for CloneGitRepository and LinkExpand updated to use MockFileSystem, removing real temp-directory setup.