### PR TITLE
Add machine-specific task filtering via tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Feature updates
+
+* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can now declare an
+  optional `"tags"` property (astring or array of strings). A machine's tags are defined in a `settings.json`
+  file in the platform local config directory (`%LOCALAPPDATA%\cnct\settings.json` on Windows; `$XDG_CONFIG_HOME/cnct/settings.json`
+  or `~/.config/cnct/settings.json` on Linux and macOS). An action runs if it has no tags, or if the machine's
+  tags include at least one match (case-insensitive).
+
 ### Improvements
 
 * Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem operations, enabling full unit test coverage without real disk I/O.

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Moq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class CnctConfigTagFilteringTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasNoTags()
+        {
+            var action = new TestActionSpec();
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasTags()
+        {
+            var action = new TestActionSpec();
+            var config = MakeConfig(new[] { "personal" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsTaggedAction_WhenMachineTagMatches()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(new[] { "personal" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SkipsTaggedAction_WhenNoMachineTags()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.False(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SkipsTaggedAction_WhenMachineTagsDoNotMatch()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(new[] { "work" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.False(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsTaggedAction_CaseInsensitiveMatch()
+        {
+            var action = new TestActionSpec { Tags = new[] { "Personal" } };
+            var config = MakeConfig(new[] { "personal" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsTaggedAction_WhenAnyTagMatches()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal", "home" } };
+            var config = MakeConfig(new[] { "work", "home" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsUntaggedAndSkipsTagged_Mixed()
+        {
+            var untaggedAction = new TestActionSpec();
+            var taggedAction = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(Array.Empty<string>(), untaggedAction, taggedAction);
+
+            await config.ExecuteAsync();
+
+            Assert.True(untaggedAction.WasExecuted);
+            Assert.False(taggedAction.WasExecuted);
+        }
+
+        private static CnctConfig MakeConfig(IReadOnlyCollection<string> machineTags, params ICnctActionSpec[] actions)
+        {
+            return new CnctConfig
+            {
+                Logger = Mock.Of<ILogger>(),
+                ConfigRootDirectory = "/",
+                MachineTags = machineTags,
+                Actions = actions,
+            };
+        }
+
+        private class TestActionSpec : CnctActionSpecBase
+        {
+            public bool WasExecuted { get; private set; }
+
+            public override string ActionType => "test";
+
+            public override void Validate()
+            {
+            }
+
+            public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+            {
+                this.WasExecuted = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/MachineSettingsLoaderTests.cs
+++ b/Cnct/Cnct.Core.Tests/MachineSettingsLoaderTests.cs
@@ -1,0 +1,68 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class MachineSettingsLoaderTests
+    {
+        [Fact]
+        public async Task LoadAsync_ReturnsMachineSettingsEmpty_WhenFileDoesNotExist()
+        {
+            var mockFileSystem = new MockFileSystem();
+            var loader = new MachineSettingsLoader(mockFileSystem);
+
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Same(MachineSettings.Empty, result);
+        }
+
+        [Fact]
+        public async Task LoadAsync_ReturnsTags_WhenFileExistsWithTags()
+        {
+            string path = MachineSettingsLoader.GetSettingsFilePath();
+            string json = JsonConvert.SerializeObject(new { tags = new[] { "personal", "home" } });
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.GetDirectoryName(path));
+            mockFileSystem.File.WriteAllText(path, json);
+
+            var loader = new MachineSettingsLoader(mockFileSystem);
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Contains("personal", result.Tags);
+            Assert.Contains("home", result.Tags);
+        }
+
+        [Fact]
+        public async Task LoadAsync_ReturnsSingleTag_WhenFileHasSingleStringTag()
+        {
+            string path = MachineSettingsLoader.GetSettingsFilePath();
+            string json = JsonConvert.SerializeObject(new { tags = "work" });
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.GetDirectoryName(path));
+            mockFileSystem.File.WriteAllText(path, json);
+
+            var loader = new MachineSettingsLoader(mockFileSystem);
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Single(result.Tags, "work");
+        }
+
+        [Fact]
+        public async Task LoadAsync_ReturnsEmptyTags_WhenFileHasNoTags()
+        {
+            string path = MachineSettingsLoader.GetSettingsFilePath();
+            string json = "{}";
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.GetDirectoryName(path));
+            mockFileSystem.File.WriteAllText(path, json);
+
+            var loader = new MachineSettingsLoader(mockFileSystem);
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Empty(result.Tags);
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -31,5 +31,57 @@ namespace Cnct.Core.Tests
             Assert.Equal(PlatformType.Windows, spec.PlatformType.Single());
             Assert.False(spec.Silent);
         }
+
+        [Fact]
+        public void CanDeserializeSingleTag()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+                ["os"] = "windows",
+                ["tags"] = "personal",
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Single(spec.Tags, "personal");
+        }
+
+        [Fact]
+        public void CanDeserializeTagsArray()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+                ["os"] = "windows",
+                ["tags"] = new[] { "personal", "home" },
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Equal(2, spec.Tags.Count);
+            Assert.Contains("personal", spec.Tags);
+            Assert.Contains("home", spec.Tags);
+        }
+
+        [Fact]
+        public void TagsDefaultsToEmptyWhenNotSpecified()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+                ["os"] = "windows",
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Empty(spec.Tags);
+        }
     }
 }

--- a/Cnct/Cnct.Core.Tests/StringCollectionConverterTests.cs
+++ b/Cnct/Cnct.Core.Tests/StringCollectionConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cnct.Core.Configuration;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class StringCollectionConverterTests
+    {
+        [Fact]
+        public void CanDeserializeSingleString()
+        {
+            var json = JsonConvert.SerializeObject(new { tags = "personal" });
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Equal(new[] { "personal" }, result.Tags);
+        }
+
+        [Fact]
+        public void CanDeserializeStringArray()
+        {
+            var json = JsonConvert.SerializeObject(new { tags = new[] { "personal", "home" } });
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Equal(2, result.Tags.Count);
+            Assert.Contains("personal", result.Tags);
+            Assert.Contains("home", result.Tags);
+        }
+
+        [Fact]
+        public void CanDeserializeNullAsEmptyCollection()
+        {
+            var json = "{\"tags\":null}";
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Empty(result.Tags);
+        }
+
+        [Fact]
+        public void CanDeserializeEmptyArray()
+        {
+            var json = JsonConvert.SerializeObject(new { tags = new string[0] });
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Empty(result.Tags);
+        }
+
+        [Fact]
+        public void DefaultsToEmptyCollectionWhenPropertyAbsent()
+        {
+            var json = "{}";
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Empty(result.Tags);
+        }
+
+        private class TagsWrapper
+        {
+            [JsonProperty("tags")]
+            [JsonConverter(typeof(StringCollectionConverter))]
+            public IReadOnlyCollection<string> Tags { get; set; } = System.Array.Empty<string>();
+        }
+    }
+}

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -41,6 +41,7 @@ namespace Cnct.Core
             string configFilePath = config?.FullName ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
+            cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
             cnctConfig.Validate();
             bool result = await cnctConfig.ExecuteAsync();
 

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("cloneGitRepository")]
-    public sealed partial class CloneGitRepositoryTaskSpecification : ICnctActionSpec
+    public sealed partial class CloneGitRepositoryTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileSystem fileSystem;
         private readonly IGitRunner gitRunner;
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
         [JsonProperty("repos")]
         public IReadOnlyDictionary<string, string> Repos { get; set; }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Repos == null || this.Repos.Count == 0)
             {
@@ -53,7 +53,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var normalizedRepos = new Dictionary<string, string>();
             foreach (var kvp in this.Repos)

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    public abstract class CnctActionSpecBase : ICnctActionSpec
+    {
+        [JsonProperty("tags")]
+        [JsonConverter(typeof(StringCollectionConverter))]
+        public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
+
+        public abstract string ActionType { get; }
+
+        public abstract void Validate();
+
+        public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -12,6 +13,9 @@ namespace Cnct.Core.Configuration
 
         [JsonIgnore]
         public string ConfigRootDirectory { get; set; }
+
+        [JsonIgnore]
+        public IReadOnlyCollection<string> MachineTags { get; set; } = Array.Empty<string>();
 
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }
@@ -28,6 +32,14 @@ namespace Cnct.Core.Configuration
         {
             foreach (var action in this.Actions.Where(a => a != null))
             {
+                if (action is CnctActionSpecBase taggedAction
+                    && taggedAction.Tags.Any()
+                    && !taggedAction.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                {
+                    this.Logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
+                    continue;
+                }
+
                 try
                 {
                     await action.ExecuteAsync(this.Logger, this.ConfigRootDirectory);

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -8,7 +8,7 @@ using Cnct.Core.Tasks;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("copy")]
-    public partial class CopyTaskSpecification : ICnctActionSpec
+    public partial class CopyTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileManagement fileManagement;
         private readonly IFileSystem fileSystem;
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
         {
         }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Files == null || this.Files.Count == 0)
             {
@@ -40,7 +40,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var copyTask = new CopyTask(
                 logger,

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("environmentVariable")]
-    public partial class EnvironmentVariableTaskSpecification : ICnctActionSpec
+    public partial class EnvironmentVariableTaskSpecification : CnctActionSpecBase
     {
         [JsonRequired]
         public string Name { get; set; }
@@ -17,13 +17,13 @@ namespace Cnct.Core.Configuration
         [JsonRequired]
         public string Value { get; set; }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var envVariableTask = new EnvironmentVariableTask(logger, this.Name, this.Value);
             await envVariableTask.ExecuteAsync();
         }
 
-        public void Validate()
+        public override void Validate()
         {
         }
     }

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("linkExpand")]
-    public sealed partial class LinkExpandTaskSpecification : ICnctActionSpec
+    public sealed partial class LinkExpandTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileSystem fileSystem;
 
@@ -27,7 +27,7 @@ namespace Cnct.Core.Configuration
         [JsonProperty("target")]
         public string Target { get; set; }
 
-        public void Validate()
+        public override void Validate()
         {
             if (string.IsNullOrWhiteSpace(this.Source))
             {
@@ -40,7 +40,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             string source = this.Source.NormalizePath();
             if (!this.fileSystem.Path.IsPathRooted(source))

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("link")]
-    public sealed partial class LinkTaskSpecification : ICnctActionSpec
+    public sealed partial class LinkTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileManagement fileManagement;
         private readonly IFileSystem fileSystem;
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Links { get; set; }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Links == null || this.Links.Count == 0)
             {
@@ -40,7 +40,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var linkTask = new LinkTask(
                 logger,

--- a/Cnct/Cnct.Core/Configuration/MachineSettings.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettings.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    public class MachineSettings
+    {
+        public static readonly MachineSettings Empty = new MachineSettings();
+
+        [JsonProperty("tags")]
+        [JsonConverter(typeof(StringCollectionConverter))]
+        public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    public class MachineSettingsLoader
+    {
+        private readonly IFileSystem fileSystem;
+
+        public MachineSettingsLoader()
+            : this(new FileSystem())
+        {
+        }
+
+        public MachineSettingsLoader(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public static string GetSettingsFilePath()
+        {
+            return Path.Combine(GetSettingsDirectory(), "cnct", "settings.json");
+        }
+
+        public async Task<MachineSettings> LoadAsync()
+        {
+            string path = GetSettingsFilePath();
+            if (!this.fileSystem.File.Exists(path))
+            {
+                return MachineSettings.Empty;
+            }
+
+            string json = await this.fileSystem.File.ReadAllTextAsync(path);
+            return JsonConvert.DeserializeObject<MachineSettings>(json) ?? MachineSettings.Empty;
+        }
+
+        private static string GetSettingsDirectory()
+        {
+            switch (Platform.CurrentPlatform)
+            {
+                case PlatformType.Windows:
+                    return Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                case PlatformType.Linux:
+                case PlatformType.OSX:
+                    return Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ?? Path.Combine(Platform.Home, ".config");
+                default:
+                    throw new NotImplementedException($"Platform '{Platform.CurrentPlatform}' is not supported.");
+            }
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("shell")]
-    public partial class ShellTaskSpecification : ICnctActionSpec
+    public partial class ShellTaskSpecification : CnctActionSpecBase
     {
         [JsonRequired]
         public ShellType Shell { get; set; }
@@ -23,7 +23,7 @@ namespace Cnct.Core.Configuration
 
         public bool Silent { get; set; }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             if (!this.PlatformType.Contains(Platform.CurrentPlatform))
             {
@@ -41,7 +41,7 @@ namespace Cnct.Core.Configuration
             await shellInvoker.ExecuteAsync(this);
         }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Shell == ShellType.Unknown)
             {

--- a/Cnct/Cnct.Core/Configuration/StringCollectionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/StringCollectionConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cnct.Core.Configuration
+{
+    public class StringCollectionConverter : JsonConverter<IReadOnlyCollection<string>>
+    {
+        public override IReadOnlyCollection<string> ReadJson(
+            JsonReader reader,
+            Type objectType,
+            IReadOnlyCollection<string> existingValue,
+            bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            return token.Type switch
+            {
+                JTokenType.Array => new HashSet<string>(((JArray)token).Select(e => e.Value<string>())),
+                JTokenType.String => new HashSet<string> { token.Value<string>() },
+                JTokenType.Null => new HashSet<string>(),
+                _ => throw new JsonSerializationException(),
+            };
+        }
+
+        public override void WriteJson(JsonWriter writer, IReadOnlyCollection<string> value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
+++ b/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
@@ -83,7 +82,7 @@ namespace {NamespaceCnctCoreConfiguration}
 {{
     public partial class {className}
     {{
-        public string ActionType {{ get; }} = ""{actionType}"";
+        public override string ActionType {{ get; }} = ""{actionType}"";
     }}
 }}
 ";
@@ -93,16 +92,17 @@ namespace {NamespaceCnctCoreConfiguration}
 
         private class ActionSpecSyntaxReceiver : ISyntaxReceiver
         {
+            private const string CnctActionTypeAttributeName = "CnctActionType";
+
             public ISet<ClassDeclarationSyntax> ClassesToAugment { get; } = new HashSet<ClassDeclarationSyntax>();
 
             public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
             {
                 if (syntaxNode is ClassDeclarationSyntax cds &&
-                        cds.BaseList?.Types
-                            .Where(t => t.Type.IsKind(SyntaxKind.IdentifierName))
-                            .Select(t => t.Type)
-                            .Cast<IdentifierNameSyntax>()
-                            .Any(t => t.Identifier.ValueText == CnctActionSpecInterfaceName) == true)
+                    cds.AttributeLists
+                        .SelectMany(al => al.Attributes)
+                        .Any(a => a.Name is IdentifierNameSyntax id &&
+                                  id.Identifier.ValueText == CnctActionTypeAttributeName))
                 {
                     this.ClassesToAugment.Add(cds);
                 }

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -58,6 +58,21 @@
                 "description": {
                     "description": "A description for the action.",
                     "type": "string"
+                },
+                "tags": {
+                    "description": "Machine tags required for this action to run. If omitted or empty, the action runs on all machines. If specified, the action only runs when the machine's settings.json includes at least one matching tag.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## Summary

Each action in `cnct.json` can now declare an optional `"tags"` property (a string or array of strings). A machine's tags are defined in a `settings.json` file in the platform local config directory. An action runs if it has no tags, or if the machine's tags include at least one match (case-insensitive). If `settings.json` is missing the machine has no tags and all tagged actions are skipped.

## Machine settings file location

| Platform | Path |
|----------|------|
| Windows | `%LOCALAPPDATA%\cnct\settings.json` |
| Linux / macOS | `$XDG_CONFIG_HOME/cnct/settings.json` (fallback: `~/.config/cnct/settings.json`) |

## Example

```json
// ~/.config/cnct/settings.json (personal machine)
{ "tags": ["personal"] }
```

```json
// cnct.json
{
  "actions": [
    { "actionType": "shell", "command": "echo always runs", "shell": "powershell", "os": "windows" },
    { "actionType": "shell", "tags": ["personal"], "command": "echo personal only", "shell": "powershell", "os": "windows" },
    { "actionType": "shell", "tags": ["work"], "command": "echo work only", "shell": "powershell", "os": "windows" }
  ]
}
```

## Changes

- **`CnctActionSpecBase`** — new abstract base class all spec classes extend; provides the `tags` property via JSON deserialization
- **`StringCollectionConverter`** — deserializes a JSON string or string array into `IReadOnlyCollection<string>`
- **`MachineSettings`** — model for the machine identity file
- **`MachineSettingsLoader`** — async loader with platform-specific path resolution
- **All 6 spec classes** — extend `CnctActionSpecBase` instead of `ICnctActionSpec` directly
- **`CnctConfig`** — `MachineTags` property; `ExecuteAsync` skips tagged actions with no matching machine tag
- **Source generator** — detects specs via `[CnctActionType]` attribute (not `ICnctActionSpec` in base list); emits `override` on `ActionType`
- **JSON schema** — `"tags"` added to `ActionBase`
- **64 tests passing**
