### PR TITLE
Fix CHANGELOG line lengths to comply with markdownlint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,12 +18,17 @@ Cnct/
 
 Each task type requires **two** files in `Cnct.Core`:
 
-1. **`Configuration/<Name>TaskSpecification.cs`** — JSON-deserializable config class, decorated with `[CnctActionType("<actionType>")]`. Implements `ICnctActionSpec` (`Validate()` + `ExecuteAsync(ILogger, configDirectoryRoot)`). Must be `public sealed partial` — the source generator emits the `ActionType` property and wires it into `CnctActionConverter`.
+1. **`Configuration/<Name>TaskSpecification.cs`** — JSON-deserializable config class, decorated
+   with `[CnctActionType("<actionType>")]`. Extends `CnctActionSpecBase` (which implements
+   `ICnctActionSpec`) and overrides `Validate()` + `ExecuteAsync(ILogger, configDirectoryRoot)`.
+   Must be `public sealed partial` — the source generator emits the `ActionType` property and
+   wires it into `CnctActionConverter`.
 
 2. **`Tasks/<Name>Task.cs`** — `internal` class extending `CnctTaskBase`, does the actual work. Created and called by the specification's `ExecuteAsync`.
 
-The source generator (`CnctTaskSpecificationGenerator`) scans for classes implementing `ICnctActionSpec` decorated with `[CnctActionType]` and generates:
-- A partial `ActionType` property on the spec class
+The source generator (`CnctTaskSpecificationGenerator`) scans for classes decorated with
+`[CnctActionType]` and generates:
+- A partial `override ActionType` property on the spec class
 - A `switch` arm in `CnctActionConverter.GetActionSpecFromType()` to deserialize it
 
 **No manual registration is needed** — adding the attribute is sufficient.
@@ -77,6 +82,14 @@ The spec class should expose a constructor accepting the interface so tests can 
 1. A `$ref` added to `actions.items.oneOf`
 2. A new `definitions/<Name>Action` block with `allOf: [ActionBase, { required, properties }]`
 
+## Code style
+
+- **Maximum line length is 120 characters** for all C# source files.
+
 ## Changelog
 
-`CHANGELOG.md` — new features go under `## Unreleased → ### Feature updates`, fixes under `### Fixes`.
+`CHANGELOG.md` — new features go under `## Unreleased → ### Feature updates`, fixes under
+`### Fixes`. All edits must comply with `.markdownlint.json`:
+
+- Maximum line length **104 characters** (code blocks are exempt)
+- Wrap continuation lines with 2-space indent to stay within the limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Feature updates
 
-* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can now declare an
-  optional `"tags"` property (astring or array of strings). A machine's tags are defined in a `settings.json`
-  file in the platform local config directory (`%LOCALAPPDATA%\cnct\settings.json` on Windows; `$XDG_CONFIG_HOME/cnct/settings.json`
-  or `~/.config/cnct/settings.json` on Linux and macOS). An action runs if it has no tags, or if the machine's
-  tags include at least one match (case-insensitive).
+* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can
+  optionally declare a `"tags"` property (a string or array of strings). A machine's tags
+  are defined in a `settings.json` file in the platform local config directory
+  (`%LOCALAPPDATA%\cnct\settings.json` on Windows;
+  `$XDG_CONFIG_HOME/cnct/settings.json` or `~/.config/cnct/settings.json` on Linux and
+  macOS). An action runs if it has no tags, or if the machine's tags include at least one
+  match (case-insensitive).
 
 ### Improvements
 


### PR DESCRIPTION
Fixes line lengths in the CHANGELOG entry added in #72 to comply with
`.markdownlint.json` (max 104 characters per line).

Also fixes a typo: `astring` → `a string`.
