### PR TITLE
Release 0.5.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,12 +18,17 @@ Cnct/
 
 Each task type requires **two** files in `Cnct.Core`:
 
-1. **`Configuration/<Name>TaskSpecification.cs`** — JSON-deserializable config class, decorated with `[CnctActionType("<actionType>")]`. Implements `ICnctActionSpec` (`Validate()` + `ExecuteAsync(ILogger, configDirectoryRoot)`). Must be `public sealed partial` — the source generator emits the `ActionType` property and wires it into `CnctActionConverter`.
+1. **`Configuration/<Name>TaskSpecification.cs`** — JSON-deserializable config class, decorated
+   with `[CnctActionType("<actionType>")]`. Extends `CnctActionSpecBase` (which implements
+   `ICnctActionSpec`) and overrides `Validate()` + `ExecuteAsync(ILogger, configDirectoryRoot)`.
+   Must be `public sealed partial` — the source generator emits the `ActionType` property and
+   wires it into `CnctActionConverter`.
 
 2. **`Tasks/<Name>Task.cs`** — `internal` class extending `CnctTaskBase`, does the actual work. Created and called by the specification's `ExecuteAsync`.
 
-The source generator (`CnctTaskSpecificationGenerator`) scans for classes implementing `ICnctActionSpec` decorated with `[CnctActionType]` and generates:
-- A partial `ActionType` property on the spec class
+The source generator (`CnctTaskSpecificationGenerator`) scans for classes decorated with
+`[CnctActionType]` and generates:
+- A partial `override ActionType` property on the spec class
 - A `switch` arm in `CnctActionConverter.GetActionSpecFromType()` to deserialize it
 
 **No manual registration is needed** — adding the attribute is sufficient.
@@ -77,6 +82,14 @@ The spec class should expose a constructor accepting the interface so tests can 
 1. A `$ref` added to `actions.items.oneOf`
 2. A new `definitions/<Name>Action` block with `allOf: [ActionBase, { required, properties }]`
 
+## Code style
+
+- **Maximum line length is 120 characters** for all C# source files.
+
 ## Changelog
 
-`CHANGELOG.md` — new features go under `## Unreleased → ### Feature updates`, fixes under `### Fixes`.
+`CHANGELOG.md` — new features go under `## Unreleased → ### Feature updates`, fixes under
+`### Fixes`. All edits must comply with `.markdownlint.json`:
+
+- Maximum line length **104 characters** (code blocks are exempt)
+- Wrap continuation lines with 2-space indent to stay within the limit

--- a/.github/skills/release-next-version/SKILL.md
+++ b/.github/skills/release-next-version/SKILL.md
@@ -140,13 +140,89 @@ cause the command to hang in sync PowerShell sessions:
 
 The command prints the new PR URL on success (e.g. `https://github.com/bgold09/cnct-net/pull/65`).
 
-### 9. Open the pull request in the browser
+### 9. Wait for CI on PR 1 (`release-<version>` → `release`)
+
+Stream CI status until all three matrix checks complete. Run in **async mode** and read output
+with `read_powershell` — this can take several minutes:
 
 ```powershell
-& $gh pr view --web
+# async mode
+& $gh pr checks --watch
 ```
 
-Or use the PR URL returned in step 8 to open it.
+The three required checks are:
+- `build (ubuntu-latest)`
+- `build (windows-latest)`
+- `build (macos-latest)`
+
+If any check fails, **stop** — do not proceed to the merge step. Investigate the failure first.
+
+### 10. Merge PR 1
+
+```powershell
+& $gh pr merge --merge
+```
+
+This merges `release-<version>` into `release`. The GitHub ruleset enforces the merge method;
+do **not** use `--squash` or `--rebase`.
+
+### 11. Create PR 2 (`release` → `main`)
+
+Run in **async mode** and capture the printed PR URL:
+
+```powershell
+# async mode
+& $gh pr create --base main --head release --title "Release <version>" --body "Release <version>"
+```
+
+The command prints the new PR URL (e.g. `https://github.com/bgold09/cnct-net/pull/66`).
+Store it as `$pr2`.
+
+### 12. Wait for CI on PR 2
+
+```powershell
+# async mode
+& $gh pr checks $pr2 --watch
+```
+
+Wait for all three `build (ubuntu-latest)` / `build (windows-latest)` / `build (macos-latest)`
+checks to pass. Stop and investigate if any fail.
+
+### 13. Merge PR 2
+
+```powershell
+& $gh pr merge $pr2 --merge
+```
+
+Do **not** use `--squash` or `--rebase`.
+
+### 14. Create PR 3 (`main` → `develop`)
+
+Run in **async mode** and capture the printed PR URL:
+
+```powershell
+# async mode
+& $gh pr create --base develop --head main --title "Merge main into develop after release <version>" --body "Back-merge main into develop after releasing <version>."
+```
+
+Store the returned URL as `$pr3`.
+
+### 15. Wait for CI on PR 3
+
+```powershell
+# async mode
+& $gh pr checks $pr3 --watch
+```
+
+Wait for all three matrix checks to pass. Stop and investigate if any fail.
+
+### 16. Merge PR 3
+
+```powershell
+& $gh pr merge $pr3 --merge
+```
+
+Do **not** use `--squash` or `--rebase`. This preserves full commit history on `develop`.
 
 ## Checklist
 
@@ -157,5 +233,12 @@ Or use the PR URL returned in step 8 to open it.
 - [ ] `<BaseVersion>` in `Cnct/Cnct.NetCore/Cnct.NetCore.csproj` updated
 - [ ] Both files staged and committed with message `Release <version>`
 - [ ] Branch pushed to origin
-- [ ] PR created targeting the `release` branch
-- [ ] PR opened in browser
+- [ ] PR 1 created (`release-<version>` → `release`)
+- [ ] PR 1 CI passed (all three matrix checks green)
+- [ ] PR 1 merged with merge method
+- [ ] PR 2 created (`release` → `main`)
+- [ ] PR 2 CI passed (all three matrix checks green)
+- [ ] PR 2 merged with merge method
+- [ ] PR 3 created (`main` → `develop`)
+- [ ] PR 3 CI passed (all three matrix checks green)
+- [ ] PR 3 merged with merge method

--- a/.github/skills/release-next-version/SKILL.md
+++ b/.github/skills/release-next-version/SKILL.md
@@ -49,19 +49,61 @@ git checkout -b release-<new-version>   # e.g. release-0.4.0
 
 ### 4. Update CHANGELOG.md
 
-Transform the `## Unreleased` section:
+#### 4a. Find PRs merged since the last release
+
+Identify the last released version by reading the most recent versioned heading in `CHANGELOG.md`
+(e.g. `## 0.4.0`). Find its commit on `develop`:
+
+```powershell
+# The release commit message is always "Release <version>"
+$lastReleaseCommit = git log --oneline --format="%H" --grep "^Release " -1
+```
+
+List all PRs merged into `develop` after that commit:
+
+```powershell
+& $gh pr list --state merged --base develop --limit 50 `
+    --json number,title,url,mergedAt
+```
+
+Filter to those merged after the release commit's date. Each entry in the JSON has `number`,
+`title`, and `url`.
+
+#### 4b. Add PR links to each changelog entry
+
+For each `* ` bullet in the `## Unreleased` section, identify the PR that introduced it by
+matching the entry topic to the PR title/description. Append a link at the end:
+
+```markdown
+* Add `linkExpand` task ... ([#60](https://github.com/bgold09/cnct-net/pull/60))
+```
+
+- If a single PR introduced multiple entries, each entry gets the same link.
+- If an entry was introduced by a PR already noted inline, do not duplicate the link.
+- If no confident match can be found, leave the entry without a link rather than guessing.
+
+Multi-line entries: place the link at the end of the final continuation line:
+
+```markdown
+* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can
+  optionally declare a `"tags"` property (a string or array of strings).
+  ([#72](https://github.com/bgold09/cnct-net/pull/72))
+```
+
+#### 4c. Transform the `## Unreleased` section
+
 - **Before** (example):
   ```markdown
   ## Unreleased
 
   ### Feature updates
 
-  * Add `linkExpand` task ...
-  * Add `cloneGitRepository` task ...
+  * Add `linkExpand` task ... ([#60](https://github.com/bgold09/cnct-net/pull/60))
+  * Add `cloneGitRepository` task ... ([#61](https://github.com/bgold09/cnct-net/pull/61))
 
   ### Fixes
 
-  * Align version of `Microsoft.PowerShell.SDK` ...
+  * Align version of `Microsoft.PowerShell.SDK` ... ([#59](https://github.com/bgold09/cnct-net/pull/59))
   ```
 - **After**:
   ```markdown
@@ -71,12 +113,12 @@ Transform the `## Unreleased` section:
 
   ### Feature updates
 
-  * Add `linkExpand` task ...
-  * Add `cloneGitRepository` task ...
+  * Add `linkExpand` task ... ([#60](https://github.com/bgold09/cnct-net/pull/60))
+  * Add `cloneGitRepository` task ... ([#61](https://github.com/bgold09/cnct-net/pull/61))
 
   ### Fixes
 
-  * Align version of `Microsoft.PowerShell.SDK` ...
+  * Align version of `Microsoft.PowerShell.SDK` ... ([#59](https://github.com/bgold09/cnct-net/pull/59))
   ```
 
 Rules:
@@ -229,7 +271,8 @@ Do **not** use `--squash` or `--rebase`. This preserves full commit history on `
 - [ ] Unreleased changelog entries identified and change type determined (feature/fix/breaking)
 - [ ] New version number calculated using semver
 - [ ] Branch `release-<version>` created from latest `develop`
-- [ ] `CHANGELOG.md` updated: unreleased items moved under new version heading, `## Unreleased` left empty
+- [ ] `CHANGELOG.md` updated: PR links added to each entry, unreleased items moved under new
+  version heading, `## Unreleased` left empty
 - [ ] `<BaseVersion>` in `Cnct/Cnct.NetCore/Cnct.NetCore.csproj` updated
 - [ ] Both files staged and committed with message `Release <version>`
 - [ ] Branch pushed to origin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Feature updates
+
+* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can now declare an
+  optional `"tags"` property (astring or array of strings). A machine's tags are defined in a `settings.json`
+  file in the platform local config directory (`%LOCALAPPDATA%\cnct\settings.json` on Windows; `$XDG_CONFIG_HOME/cnct/settings.json`
+  or `~/.config/cnct/settings.json` on Linux and macOS). An action runs if it has no tags, or if the machine's
+  tags include at least one match (case-insensitive).
+
 ### Improvements
 
 * Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem operations, enabling full unit test coverage without real disk I/O.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Feature updates
 
-* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can now declare an
-  optional `"tags"` property (astring or array of strings). A machine's tags are defined in a `settings.json`
-  file in the platform local config directory (`%LOCALAPPDATA%\cnct\settings.json` on Windows; `$XDG_CONFIG_HOME/cnct/settings.json`
-  or `~/.config/cnct/settings.json` on Linux and macOS). An action runs if it has no tags, or if the machine's
-  tags include at least one match (case-insensitive).
+* Add support for machine-specific task filtering via tags. Each action in `cnct.json` can
+  optionally declare a `"tags"` property (a string or array of strings). A machine's tags
+  are defined in a `settings.json` file in the platform local config directory
+  (`%LOCALAPPDATA%\cnct\settings.json` on Windows;
+  `$XDG_CONFIG_HOME/cnct/settings.json` or `~/.config/cnct/settings.json` on Linux and
+  macOS). An action runs if it has no tags, or if the machine's tags include at least one
+  match (case-insensitive).
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+* Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem operations, enabling full unit test coverage without real disk I/O.
+
 ## 0.4.0
 
 ### Feature updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.5.0
+
 ### Feature updates
 
 * Add support for machine-specific task filtering via tags. Each action in `cnct.json` can
@@ -11,10 +13,13 @@
   `$XDG_CONFIG_HOME/cnct/settings.json` or `~/.config/cnct/settings.json` on Linux and
   macOS). An action runs if it has no tags, or if the machine's tags include at least one
   match (case-insensitive).
+  ([#72](https://github.com/bgold09/cnct-net/pull/72))
 
 ### Improvements
 
-* Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem operations, enabling full unit test coverage without real disk I/O.
+* Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem
+  operations, enabling full unit test coverage without real disk I/O.
+  ([#70](https://github.com/bgold09/cnct-net/pull/70))
 
 ## 0.4.0
 

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
@@ -113,16 +114,16 @@ namespace Cnct.Core.Tests
             string relativeDest = Path.Combine("dev", "repo-a");
             string expectedDest = Path.Combine(configRoot, relativeDest);
 
+            var mockFileSystem = new MockFileSystem();
             var mockRunner = new Mock<IGitRunner>();
             mockRunner.Setup(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
-            var logger = Mock.Of<ILogger>();
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
                 Repos = new Dictionary<string, string> { [url] = relativeDest },
             };
 
-            await spec.ExecuteAsync(logger, configRoot);
+            await spec.ExecuteAsync(Mock.Of<ILogger>(), configRoot);
 
             mockRunner.Verify(
                 r => r.CloneAsync(url, expectedDest),
@@ -135,10 +136,11 @@ namespace Cnct.Core.Tests
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "repo-a");
             const string url = "https://example.com/org/repo-a";
 
+            var mockFileSystem = new MockFileSystem();
             var mockRunner = new Mock<IGitRunner>();
             mockRunner.Setup(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
                 Repos = new Dictionary<string, string> { [url] = dest },
             };
@@ -153,83 +155,70 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_PullsWhenDotGitDirectoryExists()
         {
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(Path.Combine(dest, ".git"));
-            try
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.Combine(dest, ".git"));
+
+            const string url = "https://example.com/org/repo-a";
+            var mockRunner = new Mock<IGitRunner>();
+            mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
-                const string url = "https://example.com/org/repo-a";
-                var mockRunner = new Mock<IGitRunner>();
-                mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+                Repos = new Dictionary<string, string> { [url] = dest },
+            };
 
-                var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
-                {
-                    Repos = new Dictionary<string, string> { [url] = dest },
-                };
+            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
 
-                await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-                mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
-                mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            }
-            finally
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+            mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
+            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_PullsWhenDotGitFileExists()
         {
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(dest);
-            File.WriteAllText(Path.Combine(dest, ".git"), "gitdir: ../.git/worktrees/worktree1");
-            try
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(dest);
+            mockFileSystem.File.WriteAllText(
+                mockFileSystem.Path.Combine(dest, ".git"),
+                "gitdir: ../.git/worktrees/worktree1");
+
+            const string url = "https://example.com/org/repo-a";
+            var mockRunner = new Mock<IGitRunner>();
+            mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
-                const string url = "https://example.com/org/repo-a";
-                var mockRunner = new Mock<IGitRunner>();
-                mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+                Repos = new Dictionary<string, string> { [url] = dest },
+            };
 
-                var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
-                {
-                    Repos = new Dictionary<string, string> { [url] = dest },
-                };
+            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
 
-                await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-                mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
-                mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            }
-            finally
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+            mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
+            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_LogsWarningWhenDestExistsButIsNotGitRepo()
         {
             string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(dest);
-            try
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(dest);
+
+            const string url = "https://example.com/org/repo-a";
+            var mockRunner = new Mock<IGitRunner>();
+            var logger = new Mock<ILogger>();
+
+            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem)
             {
-                const string url = "https://example.com/org/repo-a";
-                var mockRunner = new Mock<IGitRunner>();
-                var logger = new Mock<ILogger>();
+                Repos = new Dictionary<string, string> { [url] = dest },
+            };
 
-                var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object)
-                {
-                    Repos = new Dictionary<string, string> { [url] = dest },
-                };
+            await spec.ExecuteAsync(logger.Object, Path.GetTempPath());
 
-                await spec.ExecuteAsync(logger.Object, Path.GetTempPath());
-
-                logger.Verify(l => l.LogWarning(It.Is<string>(s => s.Contains(dest))), Times.Once);
-                mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-                mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
-            }
-            finally
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+            logger.Verify(l => l.LogWarning(It.Is<string>(s => s.Contains(dest))), Times.Once);
+            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
+++ b/Cnct/Cnct.Core.Tests/Cnct.Core.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Moq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class CnctConfigTagFilteringTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasNoTags()
+        {
+            var action = new TestActionSpec();
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasTags()
+        {
+            var action = new TestActionSpec();
+            var config = MakeConfig(new[] { "personal" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsTaggedAction_WhenMachineTagMatches()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(new[] { "personal" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SkipsTaggedAction_WhenNoMachineTags()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.False(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SkipsTaggedAction_WhenMachineTagsDoNotMatch()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(new[] { "work" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.False(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsTaggedAction_CaseInsensitiveMatch()
+        {
+            var action = new TestActionSpec { Tags = new[] { "Personal" } };
+            var config = MakeConfig(new[] { "personal" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsTaggedAction_WhenAnyTagMatches()
+        {
+            var action = new TestActionSpec { Tags = new[] { "personal", "home" } };
+            var config = MakeConfig(new[] { "work", "home" }, action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsUntaggedAndSkipsTagged_Mixed()
+        {
+            var untaggedAction = new TestActionSpec();
+            var taggedAction = new TestActionSpec { Tags = new[] { "personal" } };
+            var config = MakeConfig(Array.Empty<string>(), untaggedAction, taggedAction);
+
+            await config.ExecuteAsync();
+
+            Assert.True(untaggedAction.WasExecuted);
+            Assert.False(taggedAction.WasExecuted);
+        }
+
+        private static CnctConfig MakeConfig(IReadOnlyCollection<string> machineTags, params ICnctActionSpec[] actions)
+        {
+            return new CnctConfig
+            {
+                Logger = Mock.Of<ILogger>(),
+                ConfigRootDirectory = "/",
+                MachineTags = machineTags,
+                Actions = actions,
+            };
+        }
+
+        private class TestActionSpec : CnctActionSpecBase
+        {
+            public bool WasExecuted { get; private set; }
+
+            public override string ActionType => "test";
+
+            public override void Validate()
+            {
+            }
+
+            public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+            {
+                this.WasExecuted = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Moq;
@@ -82,13 +83,14 @@ namespace Cnct.Core.Tests
             var logger = new Mock<ILogger>();
             logger.Setup(l => l.LogWarning(It.IsAny<string>()));
 
-            var spec = new LinkExpandTaskSpecification
+            // Source dir doesn't exist in the mock filesystem → task logs a warning
+            var mockFileSystem = new MockFileSystem();
+            var spec = new LinkExpandTaskSpecification(mockFileSystem)
             {
                 Source = relativeSource,
                 Target = "~/some/target",
             };
 
-            // Source resolves to <configRoot>/skills which doesn't exist — logs warning, doesn't throw
             await spec.ExecuteAsync(logger.Object, configRoot);
 
             logger.Verify(

--- a/Cnct/Cnct.Core.Tests/MachineSettingsLoaderTests.cs
+++ b/Cnct/Cnct.Core.Tests/MachineSettingsLoaderTests.cs
@@ -1,0 +1,68 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class MachineSettingsLoaderTests
+    {
+        [Fact]
+        public async Task LoadAsync_ReturnsMachineSettingsEmpty_WhenFileDoesNotExist()
+        {
+            var mockFileSystem = new MockFileSystem();
+            var loader = new MachineSettingsLoader(mockFileSystem);
+
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Same(MachineSettings.Empty, result);
+        }
+
+        [Fact]
+        public async Task LoadAsync_ReturnsTags_WhenFileExistsWithTags()
+        {
+            string path = MachineSettingsLoader.GetSettingsFilePath();
+            string json = JsonConvert.SerializeObject(new { tags = new[] { "personal", "home" } });
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.GetDirectoryName(path));
+            mockFileSystem.File.WriteAllText(path, json);
+
+            var loader = new MachineSettingsLoader(mockFileSystem);
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Contains("personal", result.Tags);
+            Assert.Contains("home", result.Tags);
+        }
+
+        [Fact]
+        public async Task LoadAsync_ReturnsSingleTag_WhenFileHasSingleStringTag()
+        {
+            string path = MachineSettingsLoader.GetSettingsFilePath();
+            string json = JsonConvert.SerializeObject(new { tags = "work" });
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.GetDirectoryName(path));
+            mockFileSystem.File.WriteAllText(path, json);
+
+            var loader = new MachineSettingsLoader(mockFileSystem);
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Single(result.Tags, "work");
+        }
+
+        [Fact]
+        public async Task LoadAsync_ReturnsEmptyTags_WhenFileHasNoTags()
+        {
+            string path = MachineSettingsLoader.GetSettingsFilePath();
+            string json = "{}";
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.GetDirectoryName(path));
+            mockFileSystem.File.WriteAllText(path, json);
+
+            var loader = new MachineSettingsLoader(mockFileSystem);
+            MachineSettings result = await loader.LoadAsync();
+
+            Assert.Empty(result.Tags);
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -31,5 +31,57 @@ namespace Cnct.Core.Tests
             Assert.Equal(PlatformType.Windows, spec.PlatformType.Single());
             Assert.False(spec.Silent);
         }
+
+        [Fact]
+        public void CanDeserializeSingleTag()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+                ["os"] = "windows",
+                ["tags"] = "personal",
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Single(spec.Tags, "personal");
+        }
+
+        [Fact]
+        public void CanDeserializeTagsArray()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+                ["os"] = "windows",
+                ["tags"] = new[] { "personal", "home" },
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Equal(2, spec.Tags.Count);
+            Assert.Contains("personal", spec.Tags);
+            Assert.Contains("home", spec.Tags);
+        }
+
+        [Fact]
+        public void TagsDefaultsToEmptyWhenNotSpecified()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+                ["os"] = "windows",
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Empty(spec.Tags);
+        }
     }
 }

--- a/Cnct/Cnct.Core.Tests/StringCollectionConverterTests.cs
+++ b/Cnct/Cnct.Core.Tests/StringCollectionConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cnct.Core.Configuration;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class StringCollectionConverterTests
+    {
+        [Fact]
+        public void CanDeserializeSingleString()
+        {
+            var json = JsonConvert.SerializeObject(new { tags = "personal" });
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Equal(new[] { "personal" }, result.Tags);
+        }
+
+        [Fact]
+        public void CanDeserializeStringArray()
+        {
+            var json = JsonConvert.SerializeObject(new { tags = new[] { "personal", "home" } });
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Equal(2, result.Tags.Count);
+            Assert.Contains("personal", result.Tags);
+            Assert.Contains("home", result.Tags);
+        }
+
+        [Fact]
+        public void CanDeserializeNullAsEmptyCollection()
+        {
+            var json = "{\"tags\":null}";
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Empty(result.Tags);
+        }
+
+        [Fact]
+        public void CanDeserializeEmptyArray()
+        {
+            var json = JsonConvert.SerializeObject(new { tags = new string[0] });
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Empty(result.Tags);
+        }
+
+        [Fact]
+        public void DefaultsToEmptyCollectionWhenPropertyAbsent()
+        {
+            var json = "{}";
+            var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
+            Assert.Empty(result.Tags);
+        }
+
+        private class TagsWrapper
+        {
+            [JsonProperty("tags")]
+            [JsonConverter(typeof(StringCollectionConverter))]
+            public IReadOnlyCollection<string> Tags { get; set; } = System.Array.Empty<string>();
+        }
+    }
+}

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -41,6 +41,7 @@ namespace Cnct.Core
             string configFilePath = config?.FullName ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
+            cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
             cnctConfig.Validate();
             bool result = await cnctConfig.ExecuteAsync();
 

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("cloneGitRepository")]
-    public sealed partial class CloneGitRepositoryTaskSpecification : ICnctActionSpec
+    public sealed partial class CloneGitRepositoryTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileSystem fileSystem;
         private readonly IGitRunner gitRunner;
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
         [JsonProperty("repos")]
         public IReadOnlyDictionary<string, string> Repos { get; set; }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Repos == null || this.Repos.Count == 0)
             {
@@ -53,7 +53,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var normalizedRepos = new Dictionary<string, string>();
             foreach (var kvp in this.Repos)

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Newtonsoft.Json;
@@ -10,15 +10,23 @@ namespace Cnct.Core.Configuration
     [CnctActionType("cloneGitRepository")]
     public sealed partial class CloneGitRepositoryTaskSpecification : ICnctActionSpec
     {
+        private readonly IFileSystem fileSystem;
         private readonly IGitRunner gitRunner;
 
         public CloneGitRepositoryTaskSpecification()
         {
+            this.fileSystem = new FileSystem();
         }
 
         public CloneGitRepositoryTaskSpecification(IGitRunner gitRunner)
+            : this(gitRunner, new FileSystem())
+        {
+        }
+
+        public CloneGitRepositoryTaskSpecification(IGitRunner gitRunner, IFileSystem fileSystem)
         {
             this.gitRunner = gitRunner;
+            this.fileSystem = fileSystem;
         }
 
         [JsonProperty("repos")]
@@ -51,15 +59,20 @@ namespace Cnct.Core.Configuration
             foreach (var kvp in this.Repos)
             {
                 string dest = kvp.Value.NormalizePath();
-                if (!Path.IsPathRooted(dest))
+                if (!this.fileSystem.Path.IsPathRooted(dest))
                 {
-                    dest = Path.Combine(configDirectoryRoot, dest);
+                    dest = this.fileSystem.Path.Combine(configDirectoryRoot, dest);
                 }
 
                 normalizedRepos[kvp.Key] = dest;
             }
 
-            var cloneTask = new CloneGitRepositoryTask(logger, normalizedRepos, this.gitRunner ?? new ProcessGitRunner(logger));
+            var cloneTask = new CloneGitRepositoryTask(
+                logger,
+                normalizedRepos,
+                this.gitRunner ?? new ProcessGitRunner(logger),
+                this.fileSystem);
+
             return cloneTask.ExecuteAsync();
         }
     }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    public abstract class CnctActionSpecBase : ICnctActionSpec
+    {
+        [JsonProperty("tags")]
+        [JsonConverter(typeof(StringCollectionConverter))]
+        public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
+
+        public abstract string ActionType { get; }
+
+        public abstract void Validate();
+
+        public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -12,6 +13,9 @@ namespace Cnct.Core.Configuration
 
         [JsonIgnore]
         public string ConfigRootDirectory { get; set; }
+
+        [JsonIgnore]
+        public IReadOnlyCollection<string> MachineTags { get; set; } = Array.Empty<string>();
 
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }
@@ -28,6 +32,14 @@ namespace Cnct.Core.Configuration
         {
             foreach (var action in this.Actions.Where(a => a != null))
             {
+                if (action is CnctActionSpecBase taggedAction
+                    && taggedAction.Tags.Any()
+                    && !taggedAction.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                {
+                    this.Logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
+                    continue;
+                }
+
                 try
                 {
                     await action.ExecuteAsync(this.Logger, this.ConfigRootDirectory);

--- a/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
@@ -1,23 +1,31 @@
 ﻿using System;
 using System.IO;
+using System.IO.Abstractions;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {
     public class CnctConfigurationParser
     {
+        private readonly IFileSystem fileSystem;
         private readonly ILogger logger;
 
         public CnctConfigurationParser(ILogger logger)
+            : this(logger, new FileSystem())
+        {
+        }
+
+        public CnctConfigurationParser(ILogger logger, IFileSystem fileSystem)
         {
             this.logger = logger;
+            this.fileSystem = fileSystem;
         }
 
         public CnctConfig Parse(string configFile)
         {
             configFile = configFile == null
-                ? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json"
-                : Path.GetFullPath(configFile);
+                ? $"{this.fileSystem.Directory.GetCurrentDirectory()}{this.fileSystem.Path.DirectorySeparatorChar}cnct.json"
+                : this.fileSystem.Path.GetFullPath(configFile);
 
             if (string.IsNullOrWhiteSpace(configFile))
             {
@@ -26,17 +34,17 @@ namespace Cnct.Core.Configuration
                     nameof(configFile));
             }
 
-            if (!File.Exists(configFile))
+            if (!this.fileSystem.File.Exists(configFile))
             {
                 throw new FileNotFoundException("The config file does not exist.", configFile);
             }
 
             try
             {
-                string json = File.ReadAllText(configFile);
+                string json = this.fileSystem.File.ReadAllText(configFile);
                 CnctConfig config = JsonConvert.DeserializeObject<CnctConfig>(json);
                 config.Logger = this.logger;
-                config.ConfigRootDirectory = Path.GetDirectoryName(configFile);
+                config.ConfigRootDirectory = this.fileSystem.Path.GetDirectoryName(configFile);
 
                 return config;
             }

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -11,18 +11,25 @@ namespace Cnct.Core.Configuration
     public partial class CopyTaskSpecification : ICnctActionSpec
     {
         private readonly IFileManagement fileManagement;
+        private readonly IFileSystem fileSystem;
 
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Files { get; set; }
 
         public CopyTaskSpecification(IFileManagement fileManagement)
+            : this(fileManagement, new FileSystem())
+        {
+        }
+
+        public CopyTaskSpecification(IFileManagement fileManagement, IFileSystem fileSystem)
         {
             this.fileManagement = fileManagement;
+            this.fileSystem = fileSystem;
         }
 
         public CopyTaskSpecification()
+            : this(new FileManagement(), new FileSystem())
         {
-            this.fileManagement = new FileManagement();
         }
 
         public void Validate()
@@ -37,7 +44,7 @@ namespace Cnct.Core.Configuration
         {
             var copyTask = new CopyTask(
                 logger,
-                new FileSystem(),
+                this.fileSystem,
                 this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Files));
 
             await copyTask.ExecuteAsync();

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -8,7 +8,7 @@ using Cnct.Core.Tasks;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("copy")]
-    public partial class CopyTaskSpecification : ICnctActionSpec
+    public partial class CopyTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileManagement fileManagement;
         private readonly IFileSystem fileSystem;
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
         {
         }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Files == null || this.Files.Count == 0)
             {
@@ -40,7 +40,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var copyTask = new CopyTask(
                 logger,

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("environmentVariable")]
-    public partial class EnvironmentVariableTaskSpecification : ICnctActionSpec
+    public partial class EnvironmentVariableTaskSpecification : CnctActionSpecBase
     {
         [JsonRequired]
         public string Name { get; set; }
@@ -17,13 +17,13 @@ namespace Cnct.Core.Configuration
         [JsonRequired]
         public string Value { get; set; }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var envVariableTask = new EnvironmentVariableTask(logger, this.Name, this.Value);
             await envVariableTask.ExecuteAsync();
         }
 
-        public void Validate()
+        public override void Validate()
         {
         }
     }

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("linkExpand")]
-    public sealed partial class LinkExpandTaskSpecification : ICnctActionSpec
+    public sealed partial class LinkExpandTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileSystem fileSystem;
 
@@ -27,7 +27,7 @@ namespace Cnct.Core.Configuration
         [JsonProperty("target")]
         public string Target { get; set; }
 
-        public void Validate()
+        public override void Validate()
         {
             if (string.IsNullOrWhiteSpace(this.Source))
             {
@@ -40,7 +40,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             string source = this.Source.NormalizePath();
             if (!this.fileSystem.Path.IsPathRooted(source))

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -1,5 +1,5 @@
 using System;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Newtonsoft.Json;
@@ -9,6 +9,18 @@ namespace Cnct.Core.Configuration
     [CnctActionType("linkExpand")]
     public sealed partial class LinkExpandTaskSpecification : ICnctActionSpec
     {
+        private readonly IFileSystem fileSystem;
+
+        public LinkExpandTaskSpecification()
+        {
+            this.fileSystem = new FileSystem();
+        }
+
+        public LinkExpandTaskSpecification(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
         [JsonProperty("source")]
         public string Source { get; set; }
 
@@ -31,13 +43,13 @@ namespace Cnct.Core.Configuration
         public Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             string source = this.Source.NormalizePath();
-            if (!Path.IsPathRooted(source))
+            if (!this.fileSystem.Path.IsPathRooted(source))
             {
-                source = Path.Combine(configDirectoryRoot, source);
+                source = this.fileSystem.Path.Combine(configDirectoryRoot, source);
             }
 
             string target = this.Target.NormalizePath();
-            var linkExpandTask = new LinkExpandTask(logger, source, target);
+            var linkExpandTask = new LinkExpandTask(logger, source, target, this.fileSystem);
             return linkExpandTask.ExecuteAsync();
         }
     }

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("link")]
-    public sealed partial class LinkTaskSpecification : ICnctActionSpec
+    public sealed partial class LinkTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileManagement fileManagement;
         private readonly IFileSystem fileSystem;
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Links { get; set; }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Links == null || this.Links.Count == 0)
             {
@@ -40,7 +40,7 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var linkTask = new LinkTask(
                 logger,

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Newtonsoft.Json;
@@ -10,15 +11,22 @@ namespace Cnct.Core.Configuration
     public sealed partial class LinkTaskSpecification : ICnctActionSpec
     {
         private readonly IFileManagement fileManagement;
+        private readonly IFileSystem fileSystem;
 
         public LinkTaskSpecification(IFileManagement fileManagement)
+            : this(fileManagement, new FileSystem())
+        {
+        }
+
+        public LinkTaskSpecification(IFileManagement fileManagement, IFileSystem fileSystem)
         {
             this.fileManagement = fileManagement;
+            this.fileSystem = fileSystem;
         }
 
         public LinkTaskSpecification()
+            : this(new FileManagement(), new FileSystem())
         {
-            this.fileManagement = new FileManagement();
         }
 
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
@@ -35,7 +43,9 @@ namespace Cnct.Core.Configuration
         public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             var linkTask = new LinkTask(
-                logger, this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links));
+                logger,
+                this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links),
+                this.fileSystem);
 
             await linkTask.ExecuteAsync();
         }

--- a/Cnct/Cnct.Core/Configuration/MachineSettings.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettings.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    public class MachineSettings
+    {
+        public static readonly MachineSettings Empty = new MachineSettings();
+
+        [JsonProperty("tags")]
+        [JsonConverter(typeof(StringCollectionConverter))]
+        public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Cnct.Core.Configuration
+{
+    public class MachineSettingsLoader
+    {
+        private readonly IFileSystem fileSystem;
+
+        public MachineSettingsLoader()
+            : this(new FileSystem())
+        {
+        }
+
+        public MachineSettingsLoader(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public static string GetSettingsFilePath()
+        {
+            return Path.Combine(GetSettingsDirectory(), "cnct", "settings.json");
+        }
+
+        public async Task<MachineSettings> LoadAsync()
+        {
+            string path = GetSettingsFilePath();
+            if (!this.fileSystem.File.Exists(path))
+            {
+                return MachineSettings.Empty;
+            }
+
+            string json = await this.fileSystem.File.ReadAllTextAsync(path);
+            return JsonConvert.DeserializeObject<MachineSettings>(json) ?? MachineSettings.Empty;
+        }
+
+        private static string GetSettingsDirectory()
+        {
+            switch (Platform.CurrentPlatform)
+            {
+                case PlatformType.Windows:
+                    return Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                case PlatformType.Linux:
+                case PlatformType.OSX:
+                    return Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ?? Path.Combine(Platform.Home, ".config");
+                default:
+                    throw new NotImplementedException($"Platform '{Platform.CurrentPlatform}' is not supported.");
+            }
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Cnct.Core.Configuration
 {
     [CnctActionType("shell")]
-    public partial class ShellTaskSpecification : ICnctActionSpec
+    public partial class ShellTaskSpecification : CnctActionSpecBase
     {
         [JsonRequired]
         public ShellType Shell { get; set; }
@@ -23,7 +23,7 @@ namespace Cnct.Core.Configuration
 
         public bool Silent { get; set; }
 
-        public async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
+        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
             if (!this.PlatformType.Contains(Platform.CurrentPlatform))
             {
@@ -41,7 +41,7 @@ namespace Cnct.Core.Configuration
             await shellInvoker.ExecuteAsync(this);
         }
 
-        public void Validate()
+        public override void Validate()
         {
             if (this.Shell == ShellType.Unknown)
             {

--- a/Cnct/Cnct.Core/Configuration/StringCollectionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/StringCollectionConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Cnct.Core.Configuration
+{
+    public class StringCollectionConverter : JsonConverter<IReadOnlyCollection<string>>
+    {
+        public override IReadOnlyCollection<string> ReadJson(
+            JsonReader reader,
+            Type objectType,
+            IReadOnlyCollection<string> existingValue,
+            bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            return token.Type switch
+            {
+                JTokenType.Array => new HashSet<string>(((JArray)token).Select(e => e.Value<string>())),
+                JTokenType.String => new HashSet<string> { token.Value<string>() },
+                JTokenType.Null => new HashSet<string>(),
+                _ => throw new JsonSerializationException(),
+            };
+        }
+
+        public override void WriteJson(JsonWriter writer, IReadOnlyCollection<string> value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
@@ -1,24 +1,26 @@
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 
 namespace Cnct.Core.Tasks
 {
     internal class CloneGitRepositoryTask : CnctTaskBase
     {
+        private readonly IFileSystem fileSystem;
         private readonly IReadOnlyDictionary<string, string> repos;
         private readonly IGitRunner gitRunner;
 
-        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos)
-            : this(logger, repos, new ProcessGitRunner(logger))
+        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos, IGitRunner gitRunner)
+            : this(logger, repos, gitRunner, new FileSystem())
         {
         }
 
-        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos, IGitRunner gitRunner)
+        public CloneGitRepositoryTask(ILogger logger, IReadOnlyDictionary<string, string> repos, IGitRunner gitRunner, IFileSystem fileSystem)
             : base(logger)
         {
             this.repos = repos;
             this.gitRunner = gitRunner;
+            this.fileSystem = fileSystem;
         }
 
         public override async Task ExecuteAsync()
@@ -27,24 +29,24 @@ namespace Cnct.Core.Tasks
             {
                 string url = kvp.Key;
                 string dest = kvp.Value;
-                string gitPath = Path.Combine(dest, ".git");
+                string gitPath = this.fileSystem.Path.Combine(dest, ".git");
 
-                if (File.Exists(gitPath) || Directory.Exists(gitPath))
+                if (this.fileSystem.File.Exists(gitPath) || this.fileSystem.Directory.Exists(gitPath))
                 {
                     this.Logger.LogInformation($"  [GIT] Pulling latest changes in '{dest}'");
                     await this.gitRunner.PullAsync(dest);
                 }
-                else if (Directory.Exists(dest))
+                else if (this.fileSystem.Directory.Exists(dest))
                 {
                     this.Logger.LogWarning($"Directory '{dest}' exists but is not a git repository. Skipping.");
                 }
                 else
                 {
                     this.Logger.LogInformation($"  [GIT] Cloning '{url}' to '{dest}'");
-                    string parent = Path.GetDirectoryName(dest);
-                    if (!string.IsNullOrEmpty(parent) && !Directory.Exists(parent))
+                    string parent = this.fileSystem.Path.GetDirectoryName(dest);
+                    if (!string.IsNullOrEmpty(parent) && !this.fileSystem.Directory.Exists(parent))
                     {
-                        Directory.CreateDirectory(parent);
+                        this.fileSystem.Directory.CreateDirectory(parent);
                     }
 
                     await this.gitRunner.CloneAsync(url, dest);

--- a/Cnct/Cnct.Core/Tasks/LinkExpandTask.cs
+++ b/Cnct/Cnct.Core/Tasks/LinkExpandTask.cs
@@ -1,38 +1,45 @@
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Threading.Tasks;
 
 namespace Cnct.Core.Tasks
 {
     internal class LinkExpandTask : CnctTaskBase
     {
+        private readonly IFileSystem fileSystem;
         private readonly string source;
         private readonly string target;
 
         public LinkExpandTask(ILogger logger, string source, string target)
+            : this(logger, source, target, new FileSystem())
+        {
+        }
+
+        public LinkExpandTask(ILogger logger, string source, string target, IFileSystem fileSystem)
             : base(logger)
         {
             this.source = source;
             this.target = target;
+            this.fileSystem = fileSystem;
         }
 
         public override Task ExecuteAsync()
         {
-            if (!Directory.Exists(this.source))
+            if (!this.fileSystem.Directory.Exists(this.source))
             {
                 this.Logger.LogWarning($"Source directory '{this.source}' does not exist.");
                 return Task.FromResult(0);
             }
 
             var links = new Dictionary<string, IEnumerable<string>>();
-            foreach (string subdirectory in Directory.EnumerateDirectories(this.source))
+            foreach (string subdirectory in this.fileSystem.Directory.EnumerateDirectories(this.source))
             {
-                string name = Path.GetFileName(subdirectory);
-                string linkPath = Path.Combine(this.target, name);
+                string name = this.fileSystem.Path.GetFileName(subdirectory);
+                string linkPath = this.fileSystem.Path.Combine(this.target, name);
                 links[subdirectory] = new[] { linkPath };
             }
 
-            var linkTask = new LinkTask(this.Logger, links);
+            var linkTask = new LinkTask(this.Logger, links, this.fileSystem);
             return linkTask.ExecuteAsync();
         }
     }

--- a/Cnct/Cnct.Core/Tasks/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/LinkTask.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
@@ -9,12 +9,19 @@ namespace Cnct.Core.Tasks
 {
     internal class LinkTask : CnctTaskBase
     {
+        private readonly IFileSystem fileSystem;
         private readonly IDictionary<string, IEnumerable<string>> links;
 
         public LinkTask(ILogger logger, IDictionary<string, IEnumerable<string>> links)
+            : this(logger, links, new FileSystem())
+        {
+        }
+
+        public LinkTask(ILogger logger, IDictionary<string, IEnumerable<string>> links, IFileSystem fileSystem)
             : base(logger)
         {
             this.links = links;
+            this.fileSystem = fileSystem;
         }
 
         public override Task ExecuteAsync()
@@ -27,11 +34,11 @@ namespace Cnct.Core.Tasks
                 foreach (string link in destinationLinks)
                 {
                     this.Logger.LogInformation($"  [LINK] {target} -> {link}");
-                    if (File.Exists(target))
+                    if (this.fileSystem.File.Exists(target))
                     {
                         this.CreateLink(link, target, LinkType.File);
                     }
-                    else if (Directory.Exists(target))
+                    else if (this.fileSystem.Directory.Exists(target))
                     {
                         this.CreateLink(link, target, LinkType.Directory);
                     }
@@ -47,19 +54,19 @@ namespace Cnct.Core.Tasks
 
         private void CreateLink(string linkPath, string targetPath, LinkType linkType)
         {
-            if (File.Exists(linkPath))
+            if (this.fileSystem.File.Exists(linkPath))
             {
-                File.Delete(linkPath);
+                this.fileSystem.File.Delete(linkPath);
             }
-            else if (Directory.Exists(linkPath))
+            else if (this.fileSystem.Directory.Exists(linkPath))
             {
-                Directory.Delete(linkPath);
+                this.fileSystem.Directory.Delete(linkPath);
             }
 
-            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(Path.DirectorySeparatorChar)];
-            if (!Directory.Exists(destinationLinkDirectory))
+            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(this.fileSystem.Path.DirectorySeparatorChar)];
+            if (!this.fileSystem.Directory.Exists(destinationLinkDirectory))
             {
-                Directory.CreateDirectory(destinationLinkDirectory);
+                this.fileSystem.Directory.CreateDirectory(destinationLinkDirectory);
             }
 
             switch (Platform.CurrentPlatform)

--- a/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
+++ b/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cnct</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <BaseVersion>0.4.0</BaseVersion>
+    <BaseVersion>0.5.0</BaseVersion>
     <Version Condition=" '$(BuildNumber)' == '' ">$(BaseVersion)</Version>
     <Version Condition=" '$(BuildNumber)' != '' ">$(BaseVersion)-$(BuildNumber)</Version>
     <Authors>bgold09</Authors>

--- a/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
+++ b/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
@@ -83,7 +82,7 @@ namespace {NamespaceCnctCoreConfiguration}
 {{
     public partial class {className}
     {{
-        public string ActionType {{ get; }} = ""{actionType}"";
+        public override string ActionType {{ get; }} = ""{actionType}"";
     }}
 }}
 ";
@@ -93,16 +92,17 @@ namespace {NamespaceCnctCoreConfiguration}
 
         private class ActionSpecSyntaxReceiver : ISyntaxReceiver
         {
+            private const string CnctActionTypeAttributeName = "CnctActionType";
+
             public ISet<ClassDeclarationSyntax> ClassesToAugment { get; } = new HashSet<ClassDeclarationSyntax>();
 
             public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
             {
                 if (syntaxNode is ClassDeclarationSyntax cds &&
-                        cds.BaseList?.Types
-                            .Where(t => t.Type.IsKind(SyntaxKind.IdentifierName))
-                            .Select(t => t.Type)
-                            .Cast<IdentifierNameSyntax>()
-                            .Any(t => t.Identifier.ValueText == CnctActionSpecInterfaceName) == true)
+                    cds.AttributeLists
+                        .SelectMany(al => al.Attributes)
+                        .Any(a => a.Name is IdentifierNameSyntax id &&
+                                  id.Identifier.ValueText == CnctActionTypeAttributeName))
                 {
                     this.ClassesToAugment.Add(cds);
                 }

--- a/Cnct/Directory.Packages.props
+++ b/Cnct/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.15" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.15" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -58,6 +58,21 @@
                 "description": {
                     "description": "A description for the action.",
                     "type": "string"
+                },
+                "tags": {
+                    "description": "Machine tags required for this action to run. If omitted or empty, the action runs on all machines. If specified, the action only runs when the machine's settings.json includes at least one matching tag.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## 0.5.0

### Feature updates

* Add support for machine-specific task filtering via tags. ([#72](https://github.com/bgold09/cnct-net/pull/72))

### Improvements

* Migrate all tasks to use `IFileSystem` from `System.IO.Abstractions` for filesystem operations, enabling full unit test coverage without real disk I/O. ([#70](https://github.com/bgold09/cnct-net/pull/70))