### PR TITLE
Polish task start/finish display output

### DIFF
--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -110,7 +110,7 @@ namespace Cnct.Core.Tests
                 Command = "Install-Module foo",
             };
 
-            Assert.Equal("shell: 'PowerShell Install-Module foo'", spec.GetDisplayText());
+            Assert.Equal("shell: 'powerShell Install-Module foo'", spec.GetDisplayText());
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace Cnct.Core.Tests
                 Command = "echo hello",
             };
 
-            Assert.Equal("shell: 'Sh echo hello'", spec.GetDisplayText());
+            Assert.Equal("shell: 'sh echo hello'", spec.GetDisplayText());
         }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -56,7 +56,12 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        protected override string GetAdditionalDisplayText() => $"'{this.Shell} {this.Command}'";
+        protected override string GetAdditionalDisplayText()
+        {
+            string shellName = this.Shell.ToString();
+            string camelShell = char.ToLowerInvariant(shellName[0]) + shellName.Substring(1);
+            return $"'{camelShell} {this.Command}'";
+        }
 
         public enum ShellType
         {

--- a/Cnct/Cnct.Core/ConsoleLogger.cs
+++ b/Cnct/Cnct.Core/ConsoleLogger.cs
@@ -46,7 +46,7 @@ namespace Cnct.Core
         {
             if (!this.loggerOptions.Quiet)
             {
-                LogWithColor($"▶ {message}", ConsoleColor.Cyan);
+                LogWithColor($"▶ {message}", ConsoleColor.DarkCyan);
             }
         }
 
@@ -54,7 +54,7 @@ namespace Cnct.Core
         {
             if (!this.loggerOptions.Quiet)
             {
-                LogWithColor($"✓ {message}", ConsoleColor.Green);
+                LogWithColor($"✓ {message}", ConsoleColor.DarkGreen);
             }
         }
 


### PR DESCRIPTION
## Summary

Small polish changes to the task start/finish output introduced in #79.

### Changes

- **Colors**: `LogStart` now uses `DarkCyan` (▶) and `LogFinish` uses `DarkGreen` (✓),
  replacing the brighter `Cyan`/`Green` which can be harsh on both light and dark terminals
- **Shell display name**: the shell type in `shell` task output is now in camelCase
  (e.g. `powerShell` and `sh`) to match typical identifier conventions, rather than
  the enum PascalCase value (`PowerShell`, `Sh`)

### Example output

```
▶ shell: 'powerShell Install-Module Posh-Git'
  [task output]
✓ shell: 'powerShell Install-Module Posh-Git' (2.1s)
```
