### PR TITLE
Suppress start/finish logs for OS-skipped actions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -133,10 +133,16 @@ The following rules are **suppressed** (severity = none):
 - CA1031 (catching general exceptions allowed)
 - CA1819 (array properties allowed)
 
+## Markdown
+
+All markdown files must comply with `.markdownlint.json`:
+
+- **Line length** — maximum **104 characters** (code blocks are exempt)
+- **no-duplicate-heading** — disabled (duplicate headings are allowed)
+- **ul-start-left** — disabled
+- Wrap continuation lines with 2-space indent to stay within the limit
+
 ## Changelog
 
 `CHANGELOG.md` — new features go under `## Unreleased → ### Feature updates`, fixes under
-`### Fixes`. All edits must comply with `.markdownlint.json`:
-
-- Maximum line length **104 characters** (code blocks are exempt)
-- Wrap continuation lines with 2-space indent to stay within the limit
+`### Fixes`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Feature updates
 
+* The `os` property is now supported on all action types,
+  not just `shell`. When set, the action only runs on the
+  specified operating system(s).
+* Actions skipped due to OS mismatch no longer log
+  start/finish events. A verbose-only message is logged
+  instead.
 * Add `sh` shell type for running commands via `/bin/sh`
   on Linux and macOS. The `os` property on shell actions
   is now optional — when omitted, the action runs on all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,8 @@
 
 ### Feature updates
 
-* The `os` property is now supported on all action types,
-  not just `shell`. When set, the action only runs on the
-  specified operating system(s).
-* Actions skipped due to OS mismatch no longer log
-  start/finish events. A verbose-only message is logged
-  instead.
+* The `os` property is now supported on all action types. When set, the action only runs
+  on the specified operating system(s).
 * Add `sh` shell type for running commands via `/bin/sh`
   on Linux and macOS. The `os` property on shell actions
   is now optional — when omitted, the action runs on all

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -159,6 +159,67 @@ namespace Cnct.Core.Tests
             logger.Verify(l => l.LogStart("test"), Times.Once);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_SkipsAction_WhenOsDoesNotMatch()
+        {
+            var logger = new Mock<ILogger>();
+            var nonCurrentPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+            var action = new TestActionSpec
+            {
+                PlatformType = new[] { nonCurrentPlatform },
+            };
+            var config = new CnctConfig
+            {
+                Logger = logger.Object,
+                ConfigRootDirectory = "/",
+                MachineTags = Array.Empty<string>(),
+                Actions = new ICnctActionSpec[] { action },
+            };
+
+            await config.ExecuteAsync();
+
+            Assert.False(action.WasExecuted);
+            logger.Verify(
+                l => l.LogStart(It.IsAny<string>()),
+                Times.Never);
+            logger.Verify(
+                l => l.LogFinish(It.IsAny<string>()),
+                Times.Never);
+            logger.Verify(
+                l => l.LogVerbose(
+                    It.Is<string>(
+                        s => s.Contains("not applicable to current OS"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsAction_WhenOsMatches()
+        {
+            var action = new TestActionSpec
+            {
+                PlatformType = new[] { Platform.CurrentPlatform },
+            };
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsAction_WhenOsNotSpecified()
+        {
+            var action = new TestActionSpec();
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+            Assert.Null(action.PlatformType);
+        }
+
         private static CnctConfig MakeConfig(IReadOnlyCollection<string> machineTags, params ICnctActionSpec[] actions)
         {
             return new CnctConfig

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -23,6 +23,11 @@ namespace Cnct.Core.Configuration
 
         public virtual string GetDisplayText()
         {
+            if (!string.IsNullOrEmpty(this.Label))
+            {
+                return $"{this.ActionType}: {this.Label}";
+            }
+
             string extra = this.GetAdditionalDisplayText();
             return string.IsNullOrEmpty(extra)
                 ? this.ActionType

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -21,7 +21,7 @@ namespace Cnct.Core.Configuration
 
         public abstract string ActionType { get; }
 
-        public virtual string GetDisplayText()
+        public string GetDisplayText()
         {
             if (!string.IsNullOrEmpty(this.Label))
             {

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -14,6 +15,10 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(StringCollectionConverter))]
         public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
 
+        [JsonProperty("os")]
+        [JsonConverter(typeof(EnumCollectionConverter<PlatformType>))]
+        public IReadOnlyCollection<PlatformType> PlatformType { get; set; }
+
         public abstract string ActionType { get; }
 
         public virtual string GetDisplayText()
@@ -22,6 +27,13 @@ namespace Cnct.Core.Configuration
             return string.IsNullOrEmpty(extra)
                 ? this.ActionType
                 : $"{this.ActionType}: {extra}";
+        }
+
+        public bool ShouldExecuteOnCurrentPlatform()
+        {
+            return this.PlatformType == null
+                || this.PlatformType.Count == 0
+                || this.PlatformType.Contains(Platform.CurrentPlatform);
         }
 
         public abstract void Validate();

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -32,22 +32,24 @@ namespace Cnct.Core.Configuration
         {
             foreach (var action in this.Actions.Where(a => a != null))
             {
-                if (action is CnctActionSpecBase taggedAction
-                    && taggedAction.Tags.Any()
-                    && !taggedAction.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                var specBase = action as CnctActionSpecBase;
+
+                if (specBase != null
+                    && specBase.Tags.Any()
+                    && !specBase.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
                 {
                     this.Logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
                     continue;
                 }
 
-                if (action is CnctActionSpecBase platformAction
-                    && !platformAction.ShouldExecuteOnCurrentPlatform())
+                if (specBase != null
+                    && !specBase.ShouldExecuteOnCurrentPlatform())
                 {
                     this.Logger.LogVerbose($"Skipping action '{action.ActionType}': not applicable to current OS.");
                     continue;
                 }
 
-                string displayText = action is CnctActionSpecBase specBase
+                string displayText = specBase != null
                     && !string.IsNullOrEmpty(specBase.Label)
                         ? $"{specBase.ActionType}: {specBase.Label}"
                         : action.GetDisplayText();

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -40,6 +40,13 @@ namespace Cnct.Core.Configuration
                     continue;
                 }
 
+                if (action is CnctActionSpecBase platformAction
+                    && !platformAction.ShouldExecuteOnCurrentPlatform())
+                {
+                    this.Logger.LogVerbose($"Skipping action '{action.ActionType}': not applicable to current OS.");
+                    continue;
+                }
+
                 string displayText = action is CnctActionSpecBase specBase
                     && !string.IsNullOrEmpty(specBase.Label)
                         ? $"{specBase.ActionType}: {specBase.Label}"

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -32,27 +32,20 @@ namespace Cnct.Core.Configuration
         {
             foreach (var action in this.Actions.Where(a => a != null))
             {
-                var specBase = action as CnctActionSpecBase;
-
-                if (specBase != null
-                    && specBase.Tags.Any()
-                    && !specBase.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                if (action.Tags.Any()
+                    && !action.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
                 {
                     this.Logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
                     continue;
                 }
 
-                if (specBase != null
-                    && !specBase.ShouldExecuteOnCurrentPlatform())
+                if (!action.ShouldExecuteOnCurrentPlatform())
                 {
                     this.Logger.LogVerbose($"Skipping action '{action.ActionType}': not applicable to current OS.");
                     continue;
                 }
 
-                string displayText = specBase != null
-                    && !string.IsNullOrEmpty(specBase.Label)
-                        ? $"{specBase.ActionType}: {specBase.Label}"
-                        : action.GetDisplayText();
+                string displayText = action.GetDisplayText();
 
                 try
                 {

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -8,7 +9,11 @@ namespace Cnct.Core.Configuration
     {
         string ActionType { get; }
 
+        IReadOnlyCollection<string> Tags { get; }
+
         string GetDisplayText();
+
+        bool ShouldExecuteOnCurrentPlatform();
 
         void Validate();
 

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
 using Newtonsoft.Json;
@@ -16,20 +14,10 @@ namespace Cnct.Core.Configuration
         [JsonRequired]
         public string Command { get; set; }
 
-        [JsonProperty("os")]
-        [JsonConverter(typeof(EnumCollectionConverter<PlatformType>))]
-        public IReadOnlyCollection<PlatformType> PlatformType { get; set; }
-
         public bool Silent { get; set; }
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            if (this.PlatformType?.Count > 0
-                && !this.PlatformType.Contains(Platform.CurrentPlatform))
-            {
-                return;
-            }
-
             IShellInvoker shellInvoker = this.Shell switch
             {
                 ShellType.PowerShell => new PowerShellInvoker(logger),


### PR DESCRIPTION
## Summary

Move the `os` (PlatformType) property from `ShellTaskSpecification` up to `CnctActionSpecBase` so **all** action types support OS filtering (matching the JSON schema `ActionBase` definition).

When the current OS does not match an action's `os` property, the action is now skipped **before** `LogStart`/`LogFinish` are called. A verbose-only message is logged instead, keeping normal output clean.

## Changes

- **`CnctActionSpecBase`** — Added `PlatformType` property and `ShouldExecuteOnCurrentPlatform()` method
- **`CnctConfig`** — Platform check added before start/finish logging; verbose skip message on mismatch
- **`ShellTaskSpecification`** — Removed now-redundant `PlatformType` property and inline platform check
- **Tests** — 3 new tests covering OS mismatch (no start/finish logged), OS match, and unspecified OS
- **CHANGELOG** — Updated