### PR TITLE
Fix and refactor OS property in JSON schema

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,14 @@ leave any `warning SA*` or `warning CA*` in the build output.
 1. A `$ref` added to `actions.items.oneOf`
 2. A new `definitions/<Name>Action` block with `allOf: [ActionBase, { required, properties }]`
 
+`definitions/ActionBase` mirrors the properties of `CnctActionSpecBase`. When a property is
+added to or removed from `CnctActionSpecBase` (or `ICnctActionSpec`), the `ActionBase`
+definition must be updated to match.
+
+Properties backed by `StringCollectionConverter` or `EnumCollectionConverter<T>` accept either
+a single string or an array in JSON. Represent them in the schema with `oneOf: [string, array]`
+(see the `os` and `tags` properties as examples).
+
 ## Code style
 
 - **Maximum line length is 120 characters** for all C# source files.

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -36,6 +36,14 @@
         }
     }, 
     "definitions": {
+        "OsType": {
+            "type": "string",
+            "enum": [
+                "windows",
+                "linux",
+                "osx"
+            ]
+        },
         "ActionBase": {
             "type": "object",
             "required": [
@@ -43,12 +51,18 @@
             ],
             "properties": {
                 "os": {
-                    "description": "The operating system for which to execute the action.",
-                    "type": "string",
-                    "enum": [
-                        "windows",
-                        "linux",
-                        "osx"
+                    "description": "The operating system(s) for which to execute the action. If omitted, the action runs on all platforms.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OsType"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OsType"
+                            },
+                            "minItems": 1
+                        }
                     ]
                 },
                 "actionType": {

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -36,7 +36,7 @@
         }
     }, 
     "definitions": {
-        "OsType": {
+        "OperatingSystemType": {
             "type": "string",
             "enum": [
                 "windows",
@@ -54,12 +54,12 @@
                     "description": "The operating system(s) for which to execute the action. If omitted, the action runs on all platforms.",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/OsType"
+                            "$ref": "#/definitions/OperatingSystemType"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/OsType"
+                                "$ref": "#/definitions/OperatingSystemType"
                             },
                             "minItems": 1
                         }


### PR DESCRIPTION
## Summary

Fix the `os` property in the JSON schema `ActionBase` definition and refactor to eliminate duplication.

### Changes

- **Fix `os` property type**: `EnumCollectionConverter<PlatformType>` accepts both a single string and an array (just like `StringCollectionConverter` for `tags`), but the schema only allowed a single string. Updated to `oneOf: [OperatingSystemType, array of OperatingSystemType]`.
- **Extract `OperatingSystemType` definition**: The OS enum values (`windows`, `linux`, `osx`) were duplicated in the two `oneOf` branches. Extracted into a shared `definitions/OperatingSystemType` and referenced with `$ref`.
- **Update copilot instructions**: Added guidance that `ActionBase` mirrors `CnctActionSpecBase` (changes to the base class must be reflected in the schema), and that collection-converter-backed properties use `oneOf: [string, array]`.
