### PR TITLE
Add --validate / -v option for cnct config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
   platforms.
 * Each action now logs a start (`>`) and finish (`✓`) event. An optional `"label"`
   property can be added to actions in `cnct.json` to add context to the display.
+* Add `--validate` / `-v` option to validate a `cnct.json` config file without executing
+  it. Results are written to stdout as JSON (`{ "valid": bool, "issues": [...] }`) so the
+  output can be consumed by scripts and CI/CD pipelines. Exit code is `0` when the config
+  is valid and `1` when there are errors. Validation checks include:
+  * `link` / `copy`: each source file or directory must exist on disk.
+  * `linkExpand`: the source directory must exist on disk.
+  * `cloneGitRepository`: each repository URL must be a valid absolute URI.
+  * `shell`: the shell executable (`pwsh` for PowerShell, `sh` for Sh) must be on `PATH`
+    (reported as a warning rather than an error).
+  * `environmentVariable`: the variable name must not contain `=`.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@
   * `link` / `copy`: each source file or directory must exist on disk.
   * `linkExpand`: the source directory must exist on disk.
   * `cloneGitRepository`: each repository URL must be a valid absolute URI.
-  * `shell`: the shell executable (`pwsh` for PowerShell, `sh` for Sh) must be on `PATH`
-    (reported as a warning rather than an error).
-  * `environmentVariable`: the variable name must not contain `=`.
 
 ## 0.5.0
 

--- a/Cnct/.editorconfig
+++ b/Cnct/.editorconfig
@@ -35,3 +35,10 @@ dotnet_diagnostic.CA1819.severity = none
 
 # SA1201: Elements should appear in the correct order
 dotnet_diagnostic.SA1201.severity = none
+
+# SA1313: Parameter names should begin with lower-case letter
+# Suppressed for record types where positional parameters define PascalCase properties.
+dotnet_diagnostic.SA1313.severity = none
+
+# AD0001: StyleCop analyzer exception for RecordDeclaration (known bug in StyleCop.Analyzers 1.1.118)
+dotnet_diagnostic.AD0001.severity = none

--- a/Cnct/.editorconfig
+++ b/Cnct/.editorconfig
@@ -35,10 +35,3 @@ dotnet_diagnostic.CA1819.severity = none
 
 # SA1201: Elements should appear in the correct order
 dotnet_diagnostic.SA1201.severity = none
-
-# SA1313: Parameter names should begin with lower-case letter
-# Suppressed for record types where positional parameters define PascalCase properties.
-dotnet_diagnostic.SA1313.severity = none
-
-# AD0001: StyleCop analyzer exception for RecordDeclaration (known bug in StyleCop.Analyzers 1.1.118)
-dotnet_diagnostic.AD0001.severity = none

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -59,25 +60,30 @@ namespace Cnct.Core.Tests
         }
 
         [Fact]
-        public void Validate_ThrowsWhenReposIsNull()
+        public void Validate_ReturnsError_WhenReposIsNull()
         {
             var spec = new CloneGitRepositoryTaskSpecification { Repos = null };
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Fact]
-        public void Validate_ThrowsWhenReposIsEmpty()
+        public void Validate_ReturnsError_WhenReposIsEmpty()
         {
             var spec = new CloneGitRepositoryTaskSpecification
             {
                 Repos = new Dictionary<string, string>(),
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Fact]
-        public void Validate_DoesNotThrowWithValidSpec()
+        public void Validate_ReturnsNoErrors_WhenSpecIsValid()
         {
             var spec = new CloneGitRepositoryTaskSpecification
             {
@@ -87,14 +93,16 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            spec.Validate();
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.DoesNotContain(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Validate_ThrowsWhenEntryValueIsNullOrWhiteSpace(string dest)
+        public void Validate_ReturnsError_WhenEntryValueIsNullOrWhiteSpace(string dest)
         {
             var spec = new CloneGitRepositoryTaskSpecification
             {
@@ -104,7 +112,9 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Fact]
@@ -261,6 +271,41 @@ namespace Cnct.Core.Tests
             var spec = new CloneGitRepositoryTaskSpecification();
 
             Assert.Equal("cloneGitRepository", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenAllUrlsAreValidAbsoluteUris()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new Dictionary<string, string>
+                {
+                    ["https://github.com/user/repo"] = "~/dev/repo",
+                    ["ssh://git@github.com/user/repo.git"] = "~/dev/repo2",
+                },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenUrlIsNotAValidAbsoluteUri()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new Dictionary<string, string>
+                {
+                    ["not a valid url"] = "~/dev/repo",
+                },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("not a valid absolute URI", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -237,10 +237,6 @@ namespace Cnct.Core.Tests
 
             public override string ActionType => "test";
 
-            public override void Validate()
-            {
-            }
-
             public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
             {
                 this.WasExecuted = true;

--- a/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -32,6 +34,46 @@ namespace Cnct.Core.Tests
             var spec = new CopyTaskSpecification();
 
             Assert.Equal("copy", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenSourceExists()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "my-file";
+            string fullSourcePath = $"{configRoot}/{sourceFile}";
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(fullSourcePath, new MockFileData(string.Empty));
+
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenSourceDoesNotExist()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "missing-file";
+
+            var mockFs = new MockFileSystem();
+
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("does not exist", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -37,6 +38,36 @@ namespace Cnct.Core.Tests
             };
 
             Assert.Equal("environmentVariable: 'MY_VAR=hello'", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenNameIsValid()
+        {
+            var spec = new EnvironmentVariableTaskSpecification
+            {
+                Name = "MY_VAR",
+                Value = "hello",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenNameContainsEquals()
+        {
+            var spec = new EnvironmentVariableTaskSpecification
+            {
+                Name = "MY=VAR",
+                Value = "hello",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("'='", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -35,42 +36,36 @@ namespace Cnct.Core.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Validate_ThrowsWhenSourceIsNullOrWhiteSpace(string source)
+        public void Validate_ReturnsError_WhenSourceIsNullOrWhiteSpace(string source)
         {
-            var spec = new LinkExpandTaskSpecification
+            var mockFs = new MockFileSystem();
+            var spec = new LinkExpandTaskSpecification(mockFs)
             {
                 Source = source,
                 Target = "~/some/target",
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("source"));
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Validate_ThrowsWhenTargetIsNullOrWhiteSpace(string target)
+        public void Validate_ReturnsError_WhenTargetIsNullOrWhiteSpace(string target)
         {
-            var spec = new LinkExpandTaskSpecification
+            var mockFs = new MockFileSystem();
+            var spec = new LinkExpandTaskSpecification(mockFs)
             {
                 Source = "~/some/source",
                 Target = target,
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
-        }
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
 
-        [Fact]
-        public void Validate_DoesNotThrowWithValidSpec()
-        {
-            var spec = new LinkExpandTaskSpecification
-            {
-                Source = "~/dev/scripts-pr/skills",
-                Target = "~/.github/skills",
-            };
-
-            spec.Validate();
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("target"));
         }
 
         [Fact]
@@ -104,6 +99,48 @@ namespace Cnct.Core.Tests
             var spec = new LinkExpandTaskSpecification();
 
             Assert.Equal("linkExpand", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenSourceDirectoryExists()
+        {
+            const string configRoot = "/config";
+            const string source = "my-scripts";
+            string fullSourcePath = $"{configRoot}/{source}";
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddDirectory(fullSourcePath);
+
+            var spec = new LinkExpandTaskSpecification(mockFs)
+            {
+                Source = source,
+                Target = "~/some/target",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenSourceDirectoryDoesNotExist()
+        {
+            const string configRoot = "/config";
+            const string source = "missing-scripts";
+
+            var mockFs = new MockFileSystem();
+
+            var spec = new LinkExpandTaskSpecification(mockFs)
+            {
+                Source = source,
+                Target = "~/some/target",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("does not exist", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -32,6 +34,46 @@ namespace Cnct.Core.Tests
             var spec = new LinkTaskSpecification();
 
             Assert.Equal("link", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenSourceExists()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "my-file";
+            string fullSourcePath = $"{configRoot}/{sourceFile}";
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(fullSourcePath, new MockFileData(string.Empty));
+
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenSourceDoesNotExist()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "missing-file";
+
+            var mockFs = new MockFileSystem();
+
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("does not exist", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -123,6 +124,23 @@ namespace Cnct.Core.Tests
             };
 
             Assert.Equal("shell: 'sh echo hello'", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsWarning_WhenShellNotOnPath()
+        {
+            // Use a shell type that is guaranteed not to exist on PATH under this name
+            var spec = new ShellTaskSpecification
+            {
+                Shell = ShellTaskSpecification.ShellType.PowerShell,
+                Command = "echo hello",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            // The result depends on whether pwsh is installed — just verify the shape
+            // If pwsh is not on PATH, we expect a warning; if it is, we expect no issues.
+            Assert.All(issues, i => Assert.Equal(ValidationSeverity.Warning, i.Severity));
         }
     }
 }

--- a/Cnct/Cnct.Core/Cnct.Core.csproj
+++ b/Cnct/Cnct.Core/Cnct.Core.csproj
@@ -4,7 +4,8 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Cnct.Core</AssemblyName>
     <RootNamespace>Cnct.Core</RootNamespace>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
+    <NoWarn>AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cnct/Cnct.Core/Cnct.Core.csproj
+++ b/Cnct/Cnct.Core/Cnct.Core.csproj
@@ -4,8 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Cnct.Core</AssemblyName>
     <RootNamespace>Cnct.Core</RootNamespace>
-    <LangVersion>9.0</LangVersion>
-    <NoWarn>AD0001</NoWarn>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -41,14 +41,12 @@ namespace Cnct.Core
         {
             var logger = new ConsoleLogger(new LoggerOptions(quiet, debug));
             var parser = new CnctConfigurationParser(logger);
-            string configFilePath = config?.FullName
-                ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
+            string configFilePath = config?.FullName ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
             cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
 
             ConfigValidationResult validation = cnctConfig.Validate();
-
             if (validate)
             {
                 Console.WriteLine(validation.ToJson());

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -2,19 +2,21 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 
 namespace Cnct.Core
 {
     public static class CnctCommandLine
     {
-        public static async Task Invoke(string[] args)
+        public static async Task<int> Invoke(string[] args)
         {
             var rootCommand = new RootCommand
             {
                 Description = "A cross-platform bootstrapping tool. Connect your dotfiles / cnct the dots!",
-                Handler = CommandHandler.Create((Func<FileInfo, bool, bool, Task<int>>)ExecuteAsync),
+                Handler = CommandHandler.Create((Func<FileInfo, bool, bool, bool, Task<int>>)ExecuteAsync),
             };
 
             string configOptDescription = "Path to a configuration file. If not supplied, a file called 'cnct.json' "
@@ -24,6 +26,7 @@ namespace Cnct.Core
                 CreateOption<FileInfo>('c', "config", configOptDescription),
                 CreateOption<bool>('q', "quiet", "Suppress all output other than errors."),
                 CreateOption<bool>('d', "debug", "Output additional debug information."),
+                CreateOption<bool>('v', "validate", "Validate the config file and output results as JSON."),
             };
 
             foreach (var option in options)
@@ -31,18 +34,37 @@ namespace Cnct.Core
                 rootCommand.AddOption(option);
             }
 
-            await rootCommand.InvokeAsync(args);
+            return await rootCommand.InvokeAsync(args);
         }
 
-        private static async Task<int> ExecuteAsync(FileInfo config, bool quiet, bool debug)
+        private static async Task<int> ExecuteAsync(FileInfo config, bool quiet, bool debug, bool validate)
         {
             var logger = new ConsoleLogger(new LoggerOptions(quiet, debug));
             var parser = new CnctConfigurationParser(logger);
-            string configFilePath = config?.FullName ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
+            string configFilePath = config?.FullName
+                ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
             cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
-            cnctConfig.Validate();
+
+            ConfigValidationResult validation = cnctConfig.Validate();
+
+            if (validate)
+            {
+                Console.WriteLine(validation.ToJson());
+                return validation.IsValid ? 0 : 1;
+            }
+
+            if (!validation.IsValid)
+            {
+                foreach (var issue in validation.Issues.Where(i => i.Severity == ValidationSeverity.Error))
+                {
+                    logger.LogError(issue.Message);
+                }
+
+                return 1;
+            }
+
             bool result = await cnctConfig.ExecuteAsync();
 
             return result ? 0 : 1;

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -39,10 +39,8 @@ namespace Cnct.Core.Configuration
 
             if (this.Repos == null || this.Repos.Count == 0)
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     "The collection of repositories cannot be null or empty."));
                 return issues;
             }
@@ -51,27 +49,21 @@ namespace Cnct.Core.Configuration
             {
                 if (string.IsNullOrWhiteSpace(kvp.Key))
                 {
-                    issues.Add(new ValidationIssue(
+                    issues.Add(this.CreateValidationIssue(
                         ValidationSeverity.Error,
-                        this.ActionType,
-                        this.Label,
                         "Each repository entry must have a non-empty URL."));
                 }
                 else if (!Uri.TryCreate(kvp.Key, UriKind.Absolute, out _))
                 {
-                    issues.Add(new ValidationIssue(
+                    issues.Add(this.CreateValidationIssue(
                         ValidationSeverity.Error,
-                        this.ActionType,
-                        this.Label,
                         $"Repository URL is not a valid absolute URI: {kvp.Key}"));
                 }
 
                 if (string.IsNullOrWhiteSpace(kvp.Value))
                 {
-                    issues.Add(new ValidationIssue(
+                    issues.Add(this.CreateValidationIssue(
                         ValidationSeverity.Error,
-                        this.ActionType,
-                        this.Label,
                         $"The destination path for repository '{kvp.Key}' cannot be null or empty."));
                 }
             }

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -32,25 +33,50 @@ namespace Cnct.Core.Configuration
         [JsonProperty("repos")]
         public IReadOnlyDictionary<string, string> Repos { get; set; }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+
             if (this.Repos == null || this.Repos.Count == 0)
             {
-                throw new InvalidOperationException("The collection of repositories cannot be null or empty.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    "The collection of repositories cannot be null or empty."));
+                return issues;
             }
 
             foreach (var kvp in this.Repos)
             {
                 if (string.IsNullOrWhiteSpace(kvp.Key))
                 {
-                    throw new InvalidOperationException("Each repository entry must have a non-empty URL.");
+                    issues.Add(new ValidationIssue(
+                        ValidationSeverity.Error,
+                        this.ActionType,
+                        this.Label,
+                        "Each repository entry must have a non-empty URL."));
+                }
+                else if (!Uri.TryCreate(kvp.Key, UriKind.Absolute, out _))
+                {
+                    issues.Add(new ValidationIssue(
+                        ValidationSeverity.Error,
+                        this.ActionType,
+                        this.Label,
+                        $"Repository URL is not a valid absolute URI: {kvp.Key}"));
                 }
 
                 if (string.IsNullOrWhiteSpace(kvp.Value))
                 {
-                    throw new InvalidOperationException($"The destination path for repository '{kvp.Key}' cannot be null or empty.");
+                    issues.Add(new ValidationIssue(
+                        ValidationSeverity.Error,
+                        this.ActionType,
+                        this.Label,
+                        $"The destination path for repository '{kvp.Key}' cannot be null or empty."));
                 }
             }
+
+            return issues;
         }
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -36,7 +36,6 @@ namespace Cnct.Core.Configuration
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
             var issues = new List<ValidationIssue>();
-
             if (this.Repos == null || this.Repos.Count == 0)
             {
                 issues.Add(this.CreateValidationIssue(

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -38,9 +38,7 @@ namespace Cnct.Core.Configuration
             var issues = new List<ValidationIssue>();
             if (this.Repos == null || this.Repos.Count == 0)
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    "The collection of repositories cannot be null or empty."));
+                issues.Add(this.CreateValidationError("The collection of repositories cannot be null or empty."));
                 return issues;
             }
 
@@ -48,21 +46,16 @@ namespace Cnct.Core.Configuration
             {
                 if (string.IsNullOrWhiteSpace(kvp.Key))
                 {
-                    issues.Add(this.CreateValidationIssue(
-                        ValidationSeverity.Error,
-                        "Each repository entry must have a non-empty URL."));
+                    issues.Add(this.CreateValidationError("Each repository entry must have a non-empty URL."));
                 }
                 else if (!Uri.TryCreate(kvp.Key, UriKind.Absolute, out _))
                 {
-                    issues.Add(this.CreateValidationIssue(
-                        ValidationSeverity.Error,
-                        $"Repository URL is not a valid absolute URI: {kvp.Key}"));
+                    issues.Add(this.CreateValidationError($"Repository URL is not a valid absolute URI: {kvp.Key}"));
                 }
 
                 if (string.IsNullOrWhiteSpace(kvp.Value))
                 {
-                    issues.Add(this.CreateValidationIssue(
-                        ValidationSeverity.Error,
+                    issues.Add(this.CreateValidationError(
                         $"The destination path for repository '{kvp.Key}' cannot be null or empty."));
                 }
             }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -49,6 +49,11 @@ namespace Cnct.Core.Configuration
 
         public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
 
+        protected ValidationIssue CreateValidationIssue(ValidationSeverity severity, string message)
+        {
+            return new ValidationIssue(severity, this.ActionType, this.Label, message);
+        }
+
         protected virtual string GetAdditionalDisplayText() => null;
     }
 }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -51,14 +51,19 @@ namespace Cnct.Core.Configuration
 
         protected ValidationIssue CreateValidationError(string message)
         {
-            return new ValidationIssue(ValidationSeverity.Error, this.ActionType, this.Label, message);
+            return this.CreateValidationIssue(ValidationSeverity.Error, message);
         }
 
         protected ValidationIssue CreateValidationWarning(string message)
         {
-            return new ValidationIssue(ValidationSeverity.Warning, this.ActionType, this.Label, message);
+            return this.CreateValidationIssue(ValidationSeverity.Warning, message);
         }
 
         protected virtual string GetAdditionalDisplayText() => null;
+
+        private ValidationIssue CreateValidationIssue(ValidationSeverity severity, string message)
+        {
+            return new ValidationIssue(severity, this.ActionType, this.Label, message);
+        }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -49,9 +49,14 @@ namespace Cnct.Core.Configuration
 
         public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
 
-        protected ValidationIssue CreateValidationIssue(ValidationSeverity severity, string message)
+        protected ValidationIssue CreateValidationError(string message)
         {
-            return new ValidationIssue(severity, this.ActionType, this.Label, message);
+            return new ValidationIssue(ValidationSeverity.Error, this.ActionType, this.Label, message);
+        }
+
+        protected ValidationIssue CreateValidationWarning(string message)
+        {
+            return new ValidationIssue(ValidationSeverity.Warning, this.ActionType, this.Label, message);
         }
 
         protected virtual string GetAdditionalDisplayText() => null;

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -41,7 +42,10 @@ namespace Cnct.Core.Configuration
                 || this.PlatformType.Contains(Platform.CurrentPlatform);
         }
 
-        public abstract void Validate();
+        public virtual IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        {
+            return Array.Empty<ValidationIssue>();
+        }
 
         public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
 

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -36,7 +36,6 @@ namespace Cnct.Core.Configuration
             }
 
             var issues = new List<ValidationIssue>();
-
             foreach (var action in this.Actions.Where(a => a != null))
             {
                 issues.AddRange(action.Validate(this.ConfigRootDirectory));

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -20,12 +21,16 @@ namespace Cnct.Core.Configuration
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }
 
-        public void Validate()
+        public ConfigValidationResult Validate()
         {
-            foreach (var action in this.Actions)
+            var issues = new List<ValidationIssue>();
+
+            foreach (var action in (this.Actions ?? Array.Empty<ICnctActionSpec>()).Where(a => a != null))
             {
-                action.Validate();
+                issues.AddRange(action.Validate(this.ConfigRootDirectory));
             }
+
+            return new ConfigValidationResult(issues);
         }
 
         public async Task<bool> ExecuteAsync()

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -23,9 +23,21 @@ namespace Cnct.Core.Configuration
 
         public ConfigValidationResult Validate()
         {
+            if (this.Actions == null || this.Actions.Length == 0)
+            {
+                return new ConfigValidationResult(new[]
+                {
+                    new ValidationIssue(
+                        ValidationSeverity.Error,
+                        "config",
+                        null,
+                        "The configuration must contain at least one action."),
+                });
+            }
+
             var issues = new List<ValidationIssue>();
 
-            foreach (var action in (this.Actions ?? Array.Empty<ICnctActionSpec>()).Where(a => a != null))
+            foreach (var action in this.Actions.Where(a => a != null))
             {
                 issues.AddRange(action.Validate(this.ConfigRootDirectory));
             }

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -39,10 +39,8 @@ namespace Cnct.Core.Configuration
 
             if (this.Files == null || this.Files.Count == 0)
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     "The collection of files cannot be null or empty."));
                 return issues;
             }
@@ -51,10 +49,8 @@ namespace Cnct.Core.Configuration
             {
                 if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
                 {
-                    issues.Add(new ValidationIssue(
+                    issues.Add(this.CreateValidationIssue(
                         ValidationSeverity.Error,
-                        this.ActionType,
-                        this.Label,
                         $"Source path does not exist: {sourcePath}"));
                 }
             }

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 
 namespace Cnct.Core.Configuration
 {
@@ -32,12 +33,33 @@ namespace Cnct.Core.Configuration
         {
         }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+
             if (this.Files == null || this.Files.Count == 0)
             {
-                throw new InvalidOperationException("The collection of files cannot be null or empty.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    "The collection of files cannot be null or empty."));
+                return issues;
             }
+
+            foreach (string sourcePath in this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Files).Keys)
+            {
+                if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
+                {
+                    issues.Add(new ValidationIssue(
+                        ValidationSeverity.Error,
+                        this.ActionType,
+                        this.Label,
+                        $"Source path does not exist: {sourcePath}"));
+                }
+            }
+
+            return issues;
         }
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -36,7 +36,6 @@ namespace Cnct.Core.Configuration
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
             var issues = new List<ValidationIssue>();
-
             if (this.Files == null || this.Files.Count == 0)
             {
                 issues.Add(this.CreateValidationIssue(

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -38,9 +38,7 @@ namespace Cnct.Core.Configuration
             var issues = new List<ValidationIssue>();
             if (this.Files == null || this.Files.Count == 0)
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    "The collection of files cannot be null or empty."));
+                issues.Add(this.CreateValidationError("The collection of files cannot be null or empty."));
                 return issues;
             }
 
@@ -48,9 +46,7 @@ namespace Cnct.Core.Configuration
             {
                 if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
                 {
-                    issues.Add(this.CreateValidationIssue(
-                        ValidationSeverity.Error,
-                        $"Source path does not exist: {sourcePath}"));
+                    issues.Add(this.CreateValidationError($"Source path does not exist: {sourcePath}"));
                 }
             }
 

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.EnvironmentVariable;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -23,8 +24,20 @@ namespace Cnct.Core.Configuration
             await envVariableTask.ExecuteAsync();
         }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+
+            if (!string.IsNullOrEmpty(this.Name) && this.Name.Contains('='))
+            {
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    $"Environment variable '{this.Name}' contains '=', which is not valid."));
+            }
+
+            return issues;
         }
 
         protected override string GetAdditionalDisplayText() => $"'{this.Name}={this.Value}'";

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -30,10 +30,8 @@ namespace Cnct.Core.Configuration
 
             if (!string.IsNullOrEmpty(this.Name) && this.Name.Contains('='))
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     $"Environment variable '{this.Name}' contains '=', which is not valid."));
             }
 

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -27,7 +27,6 @@ namespace Cnct.Core.Configuration
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
             var issues = new List<ValidationIssue>();
-
             if (!string.IsNullOrEmpty(this.Name) && this.Name.Contains('='))
             {
                 issues.Add(this.CreateValidationIssue(

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -29,8 +29,7 @@ namespace Cnct.Core.Configuration
             var issues = new List<ValidationIssue>();
             if (!string.IsNullOrEmpty(this.Name) && this.Name.Contains('='))
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
+                issues.Add(this.CreateValidationError(
                     $"Environment variable '{this.Name}' contains '=', which is not valid."));
             }
 

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -15,7 +16,7 @@ namespace Cnct.Core.Configuration
 
         bool ShouldExecuteOnCurrentPlatform();
 
-        void Validate();
+        IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot);
 
         Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
     }

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -27,17 +29,47 @@ namespace Cnct.Core.Configuration
         [JsonProperty("target")]
         public string Target { get; set; }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+
             if (string.IsNullOrWhiteSpace(this.Source))
             {
-                throw new InvalidOperationException("A source directory must be specified.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    "A source directory must be specified."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Target))
             {
-                throw new InvalidOperationException("A target directory must be specified.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    "A target directory must be specified."));
             }
+
+            if (issues.Count == 0)
+            {
+                string source = this.Source.NormalizePath();
+                if (!this.fileSystem.Path.IsPathRooted(source))
+                {
+                    source = this.fileSystem.Path.Combine(configDirectoryRoot, source);
+                }
+
+                if (!this.fileSystem.Directory.Exists(source))
+                {
+                    issues.Add(new ValidationIssue(
+                        ValidationSeverity.Error,
+                        this.ActionType,
+                        this.Label,
+                        $"Source directory does not exist: {source}"));
+                }
+            }
+
+            return issues;
         }
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -34,16 +34,12 @@ namespace Cnct.Core.Configuration
             var issues = new List<ValidationIssue>();
             if (string.IsNullOrWhiteSpace(this.Source))
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    "A source directory must be specified."));
+                issues.Add(this.CreateValidationError("A source directory must be specified."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Target))
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    "A target directory must be specified."));
+                issues.Add(this.CreateValidationError("A target directory must be specified."));
             }
 
             if (issues.Count == 0)
@@ -56,9 +52,7 @@ namespace Cnct.Core.Configuration
 
                 if (!this.fileSystem.Directory.Exists(source))
                 {
-                    issues.Add(this.CreateValidationIssue(
-                        ValidationSeverity.Error,
-                        $"Source directory does not exist: {source}"));
+                    issues.Add(this.CreateValidationError($"Source directory does not exist: {source}"));
                 }
             }
 

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -32,7 +32,6 @@ namespace Cnct.Core.Configuration
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
             var issues = new List<ValidationIssue>();
-
             if (string.IsNullOrWhiteSpace(this.Source))
             {
                 issues.Add(this.CreateValidationIssue(

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -35,19 +35,15 @@ namespace Cnct.Core.Configuration
 
             if (string.IsNullOrWhiteSpace(this.Source))
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     "A source directory must be specified."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Target))
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     "A target directory must be specified."));
             }
 
@@ -61,10 +57,8 @@ namespace Cnct.Core.Configuration
 
                 if (!this.fileSystem.Directory.Exists(source))
                 {
-                    issues.Add(new ValidationIssue(
+                    issues.Add(this.CreateValidationIssue(
                         ValidationSeverity.Error,
-                        this.ActionType,
-                        this.Label,
                         $"Source directory does not exist: {source}"));
                 }
             }

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -38,9 +38,7 @@ namespace Cnct.Core.Configuration
             var issues = new List<ValidationIssue>();
             if (this.Links == null || this.Links.Count == 0)
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    "The collection of links cannot be null or empty."));
+                issues.Add(this.CreateValidationError("The collection of links cannot be null or empty."));
                 return issues;
             }
 
@@ -48,9 +46,7 @@ namespace Cnct.Core.Configuration
             {
                 if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
                 {
-                    issues.Add(this.CreateValidationIssue(
-                        ValidationSeverity.Error,
-                        $"Source path does not exist: {sourcePath}"));
+                    issues.Add(this.CreateValidationError($"Source path does not exist: {sourcePath}"));
                 }
             }
 

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -32,12 +33,33 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Links { get; set; }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+
             if (this.Links == null || this.Links.Count == 0)
             {
-                throw new InvalidOperationException("The collection of links cannot be null or empty.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    "The collection of links cannot be null or empty."));
+                return issues;
             }
+
+            foreach (string sourcePath in this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links).Keys)
+            {
+                if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
+                {
+                    issues.Add(new ValidationIssue(
+                        ValidationSeverity.Error,
+                        this.ActionType,
+                        this.Label,
+                        $"Source path does not exist: {sourcePath}"));
+                }
+            }
+
+            return issues;
         }
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -36,7 +36,6 @@ namespace Cnct.Core.Configuration
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
             var issues = new List<ValidationIssue>();
-
             if (this.Links == null || this.Links.Count == 0)
             {
                 issues.Add(this.CreateValidationIssue(

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -39,10 +39,8 @@ namespace Cnct.Core.Configuration
 
             if (this.Links == null || this.Links.Count == 0)
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     "The collection of links cannot be null or empty."));
                 return issues;
             }
@@ -51,10 +49,8 @@ namespace Cnct.Core.Configuration
             {
                 if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
                 {
-                    issues.Add(new ValidationIssue(
+                    issues.Add(this.CreateValidationIssue(
                         ValidationSeverity.Error,
-                        this.ActionType,
-                        this.Label,
                         $"Source path does not exist: {sourcePath}"));
                 }
             }

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
 using Cnct.Core.Validation;
@@ -47,18 +45,6 @@ namespace Cnct.Core.Configuration
                 issues.Add(this.CreateValidationError("A command must be specified."));
             }
 
-            string executable = this.Shell switch
-            {
-                ShellType.PowerShell => "pwsh",
-                ShellType.Sh => "sh",
-                _ => null,
-            };
-
-            if (executable != null && !IsOnPath(executable))
-            {
-                issues.Add(this.CreateValidationWarning($"Shell executable '{executable}' was not found on PATH."));
-            }
-
             return issues;
         }
 
@@ -67,19 +53,6 @@ namespace Cnct.Core.Configuration
             string shellName = this.Shell.ToString();
             string camelShell = char.ToLowerInvariant(shellName[0]) + shellName.Substring(1);
             return $"'{camelShell} {this.Command}'";
-        }
-
-        private static bool IsOnPath(string executable)
-        {
-            string pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-            string[] pathDirs = pathEnv.Split(Path.PathSeparator);
-            bool isWindows = Platform.CurrentPlatform == global::Cnct.Core.Configuration.PlatformType.Windows;
-            string[] extensions = isWindows
-                ? new[] { ".exe", ".cmd", ".bat" }
-                : new[] { string.Empty };
-
-            return pathDirs.Any(dir => extensions.Any(ext =>
-                File.Exists(Path.Combine(dir, executable + ext))));
         }
 
         public enum ShellType

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -37,7 +37,6 @@ namespace Cnct.Core.Configuration
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
             var issues = new List<ValidationIssue>();
-
             if (this.Shell == ShellType.Unknown)
             {
                 issues.Add(this.CreateValidationIssue(

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -30,18 +34,45 @@ namespace Cnct.Core.Configuration
             await shellInvoker.ExecuteAsync(this);
         }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+
             if (this.Shell == ShellType.Unknown)
             {
-                throw new ArgumentException(
-                    $"Shell type '{this.Shell}' not recognized.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    $"Shell type '{this.Shell}' not recognized."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Command))
             {
-                throw new ArgumentException("A command must be specified.");
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    this.ActionType,
+                    this.Label,
+                    "A command must be specified."));
             }
+
+            string executable = this.Shell switch
+            {
+                ShellType.PowerShell => "pwsh",
+                ShellType.Sh => "sh",
+                _ => null,
+            };
+
+            if (executable != null && !IsOnPath(executable))
+            {
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Warning,
+                    this.ActionType,
+                    this.Label,
+                    $"Shell executable '{executable}' was not found on PATH."));
+            }
+
+            return issues;
         }
 
         protected override string GetAdditionalDisplayText()
@@ -49,6 +80,19 @@ namespace Cnct.Core.Configuration
             string shellName = this.Shell.ToString();
             string camelShell = char.ToLowerInvariant(shellName[0]) + shellName.Substring(1);
             return $"'{camelShell} {this.Command}'";
+        }
+
+        private static bool IsOnPath(string executable)
+        {
+            string pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            string[] pathDirs = pathEnv.Split(Path.PathSeparator);
+            bool isWindows = Platform.CurrentPlatform == global::Cnct.Core.Configuration.PlatformType.Windows;
+            string[] extensions = isWindows
+                ? new[] { ".exe", ".cmd", ".bat" }
+                : new[] { string.Empty };
+
+            return pathDirs.Any(dir => extensions.Any(ext =>
+                File.Exists(Path.Combine(dir, executable + ext))));
         }
 
         public enum ShellType

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -40,19 +40,15 @@ namespace Cnct.Core.Configuration
 
             if (this.Shell == ShellType.Unknown)
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     $"Shell type '{this.Shell}' not recognized."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Command))
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Error,
-                    this.ActionType,
-                    this.Label,
                     "A command must be specified."));
             }
 
@@ -65,10 +61,8 @@ namespace Cnct.Core.Configuration
 
             if (executable != null && !IsOnPath(executable))
             {
-                issues.Add(new ValidationIssue(
+                issues.Add(this.CreateValidationIssue(
                     ValidationSeverity.Warning,
-                    this.ActionType,
-                    this.Label,
                     $"Shell executable '{executable}' was not found on PATH."));
             }
 

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -39,16 +39,12 @@ namespace Cnct.Core.Configuration
             var issues = new List<ValidationIssue>();
             if (this.Shell == ShellType.Unknown)
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    $"Shell type '{this.Shell}' not recognized."));
+                issues.Add(this.CreateValidationError($"Shell type '{this.Shell}' not recognized."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Command))
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Error,
-                    "A command must be specified."));
+                issues.Add(this.CreateValidationError("A command must be specified."));
             }
 
             string executable = this.Shell switch
@@ -60,9 +56,7 @@ namespace Cnct.Core.Configuration
 
             if (executable != null && !IsOnPath(executable))
             {
-                issues.Add(this.CreateValidationIssue(
-                    ValidationSeverity.Warning,
-                    $"Shell executable '{executable}' was not found on PATH."));
+                issues.Add(this.CreateValidationWarning($"Shell executable '{executable}' was not found on PATH."));
             }
 
             return issues;

--- a/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
+++ b/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cnct.Core.Validation
+{
+    public class ConfigValidationResult
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        };
+
+        public ConfigValidationResult(IReadOnlyList<ValidationIssue> issues)
+        {
+            this.Issues = issues;
+        }
+
+        [JsonPropertyName("valid")]
+        public bool IsValid => this.Issues.All(i => i.Severity != ValidationSeverity.Error);
+
+        [JsonPropertyName("issues")]
+        public IReadOnlyList<ValidationIssue> Issues { get; }
+
+        public string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
+    }
+}

--- a/Cnct/Cnct.Core/Validation/ValidationIssue.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationIssue.cs
@@ -2,26 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace Cnct.Core.Validation
 {
-    public class ValidationIssue
-    {
-        public ValidationIssue(ValidationSeverity severity, string actionType, string label, string message)
-        {
-            this.Severity = severity;
-            this.ActionType = actionType;
-            this.Label = label;
-            this.Message = message;
-        }
-
-        [JsonPropertyName("severity")]
-        public ValidationSeverity Severity { get; }
-
-        [JsonPropertyName("actionType")]
-        public string ActionType { get; }
-
-        [JsonPropertyName("label")]
-        public string Label { get; }
-
-        [JsonPropertyName("message")]
-        public string Message { get; }
-    }
+    public record ValidationIssue(
+        [property: JsonPropertyName("severity")] ValidationSeverity Severity,
+        [property: JsonPropertyName("actionType")] string ActionType,
+        [property: JsonPropertyName("label")] string Label,
+        [property: JsonPropertyName("message")] string Message);
 }

--- a/Cnct/Cnct.Core/Validation/ValidationIssue.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationIssue.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Cnct.Core.Validation
+{
+    public class ValidationIssue
+    {
+        public ValidationIssue(ValidationSeverity severity, string actionType, string label, string message)
+        {
+            this.Severity = severity;
+            this.ActionType = actionType;
+            this.Label = label;
+            this.Message = message;
+        }
+
+        [JsonPropertyName("severity")]
+        public ValidationSeverity Severity { get; }
+
+        [JsonPropertyName("actionType")]
+        public string ActionType { get; }
+
+        [JsonPropertyName("label")]
+        public string Label { get; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; }
+    }
+}

--- a/Cnct/Cnct.Core/Validation/ValidationIssue.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationIssue.cs
@@ -2,9 +2,26 @@ using System.Text.Json.Serialization;
 
 namespace Cnct.Core.Validation
 {
-    public record ValidationIssue(
-        [property: JsonPropertyName("severity")] ValidationSeverity Severity,
-        [property: JsonPropertyName("actionType")] string ActionType,
-        [property: JsonPropertyName("label")] string Label,
-        [property: JsonPropertyName("message")] string Message);
+    public class ValidationIssue
+    {
+        public ValidationIssue(ValidationSeverity severity, string actionType, string label, string message)
+        {
+            this.Severity = severity;
+            this.ActionType = actionType;
+            this.Label = label;
+            this.Message = message;
+        }
+
+        [JsonPropertyName("severity")]
+        public ValidationSeverity Severity { get; }
+
+        [JsonPropertyName("actionType")]
+        public string ActionType { get; }
+
+        [JsonPropertyName("label")]
+        public string Label { get; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; }
+    }
 }

--- a/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
@@ -3,7 +3,7 @@ namespace Cnct.Core.Validation
     public enum ValidationSeverity
     {
         None = 0,
-        Error = 1,
-        Warning = 2,
+        Error,
+        Warning,
     }
 }

--- a/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
@@ -1,0 +1,8 @@
+namespace Cnct.Core.Validation
+{
+    public enum ValidationSeverity
+    {
+        Error,
+        Warning,
+    }
+}

--- a/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
@@ -2,7 +2,8 @@ namespace Cnct.Core.Validation
 {
     public enum ValidationSeverity
     {
-        Error,
-        Warning,
+        None = 0,
+        Error = 1,
+        Warning = 2,
     }
 }

--- a/Cnct/Cnct.NetCore/Program.cs
+++ b/Cnct/Cnct.NetCore/Program.cs
@@ -5,9 +5,9 @@ namespace Cnct
 {
     public static class Program
     {
-        public static async Task Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            await CnctCommandLine.Invoke(args);
+            return await CnctCommandLine.Invoke(args);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `--validate` / `-v` CLI option that validates a `cnct.json` config file without executing it. Output is written to stdout as JSON, making it easy to consume in scripts and CI/CD pipelines.

## Output format

```json
{
  "valid": false,
  "issues": [
    {
      "severity": "error",
      "actionType": "link",
      "label": "My dotfiles",
      "message": "Source path does not exist: /home/user/.bashrc"
    }
  ]
}
```

Exit code is `0` when the config is valid, `1` when there are errors.

## Validation checks

| Task | Check |
|---|---|
| `link` / `copy` | Each source file or directory must exist on disk |
| `linkExpand` | Source directory must exist on disk |
| `cloneGitRepository` | Each repository URL must be a valid absolute URI |
| `shell` | Shell type must be known; command must be non-empty |
| `environmentVariable` | Variable name must not contain `=` |

## Design

- Single `Validate(string configDirectoryRoot)` method on `ICnctActionSpec` (replaces the old `void Validate()` that threw exceptions)
- `CnctActionSpecBase` provides `CreateValidationError(message)` and `CreateValidationWarning(message)` helpers so spec overrides don't repeat `this.ActionType` / `this.Label`
- `CnctConfig.Validate()` returns `ConfigValidationResult` with an error if `Actions` is null or empty
- Normal execution also calls `Validate()` first — errors block execution, warnings are ignored
