### PR TITLE
Release 0.6.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -133,10 +133,16 @@ The following rules are **suppressed** (severity = none):
 - CA1031 (catching general exceptions allowed)
 - CA1819 (array properties allowed)
 
+## Markdown
+
+All markdown files must comply with `.markdownlint.json`:
+
+- **Line length** — maximum **104 characters** (code blocks are exempt)
+- **no-duplicate-heading** — disabled (duplicate headings are allowed)
+- **ul-start-left** — disabled
+- Wrap continuation lines with 2-space indent to stay within the limit
+
 ## Changelog
 
 `CHANGELOG.md` — new features go under `## Unreleased → ### Feature updates`, fixes under
-`### Fixes`. All edits must comply with `.markdownlint.json`:
-
-- Maximum line length **104 characters** (code blocks are exempt)
-- Wrap continuation lines with 2-space indent to stay within the limit
+`### Fixes`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,24 @@ The spec class should expose a constructor accepting the interface so tests can 
 - `ExecuteAsync` behaviour: construct the spec with a mocked `IGitRunner`/`IFileSystem`/`IFileManagement`, set up real temp-directory filesystem state where needed, verify mock calls with `Moq`.
 - Specs that check filesystem state (clone vs pull, link exists vs not) set up and tear down temp directories in `try/finally`.
 
+## Building and testing
+
+Build the solution with:
+
+```
+dotnet build Cnct/Cnct.sln
+```
+
+Run all tests with:
+
+```
+dotnet test Cnct/Cnct.sln
+```
+
+**After every change, verify that the build produces zero warnings and zero errors.**
+StyleCop warnings are treated as warnings (not errors) but must still be fixed — do not
+leave any `warning SA*` or `warning CA*` in the build output.
+
 ## JSON schema
 
 `schema/cnctConfig.vnext.json` must be kept in sync with the code. Each new task type needs:
@@ -93,10 +111,15 @@ StyleCop.Analyzers (v1.1.118) is enabled on all projects. Configuration
 lives in `Cnct/.editorconfig`. Key active rules to follow:
 
 - **SA1204**: Static members must appear before non-static members.
+- **SA1202**: `public` members must appear before `protected` members, which must appear
+  before `private` members. When adding a `protected` override (e.g. `GetAdditionalDisplayText()`),
+  place it **after** all `public` members in the class.
 - **SA1101**: Prefix local calls with `this.`.
 - **SA1309**: Field names must not begin with underscore.
 - **SA1128**: Put constructor initializers on their own line.
 - **SA1502**: Element should not be on a single line.
+- **SA1513**: Closing brace must be followed by a blank line.
+- **SA1516**: Elements (methods, properties) must be separated by a blank line.
 
 The following rules are **suppressed** (severity = none):
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,6 +85,30 @@ The spec class should expose a constructor accepting the interface so tests can 
 ## Code style
 
 - **Maximum line length is 120 characters** for all C# source files.
+- **One class per file.** Do not place multiple classes in the same file.
+
+### StyleCop rules
+
+StyleCop.Analyzers (v1.1.118) is enabled on all projects. Configuration
+lives in `Cnct/.editorconfig`. Key active rules to follow:
+
+- **SA1204**: Static members must appear before non-static members.
+- **SA1101**: Prefix local calls with `this.`.
+- **SA1309**: Field names must not begin with underscore.
+- **SA1128**: Put constructor initializers on their own line.
+- **SA1502**: Element should not be on a single line.
+
+The following rules are **suppressed** (severity = none):
+
+- SA0001 (XML comment analysis disabled)
+- SA1200 (using directive placement — configured to outside namespace)
+- SA1201 (element ordering — disabled)
+- SA1600, SA1601, SA1602 (XML documentation not required)
+- SA1633 (file header not required)
+- CA1303 (localized parameters not required)
+- CA2007 (ConfigureAwait not required)
+- CA1031 (catching general exceptions allowed)
+- CA1819 (array properties allowed)
 
 ## Changelog
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,14 @@ leave any `warning SA*` or `warning CA*` in the build output.
 1. A `$ref` added to `actions.items.oneOf`
 2. A new `definitions/<Name>Action` block with `allOf: [ActionBase, { required, properties }]`
 
+`definitions/ActionBase` mirrors the properties of `CnctActionSpecBase`. When a property is
+added to or removed from `CnctActionSpecBase` (or `ICnctActionSpec`), the `ActionBase`
+definition must be updated to match.
+
+Properties backed by `StringCollectionConverter` or `EnumCollectionConverter<T>` accept either
+a single string or an array in JSON. Represent them in the schema with `oneOf: [string, array]`
+(see the `os` and `tags` properties as examples).
+
 ## Code style
 
 - **Maximum line length is 120 characters** for all C# source files.

--- a/.github/skills/release-next-version/SKILL.md
+++ b/.github/skills/release-next-version/SKILL.md
@@ -140,25 +140,47 @@ In `Cnct/Cnct.NetCore/Cnct.NetCore.csproj`, update the single `<BaseVersion>` el
 
 Only `<BaseVersion>` needs changing — `<Version>` is computed from it automatically.
 
-### 6. Commit the changes
+### 6. Copy and stamp the JSON schema
 
-Stage both files and commit with the exact message format `Release <version>`:
+Create the versioned schema directory, copy the vnext schema into it, and update
+its `"id"` to the canonical versioned URI:
 
 ```powershell
-git add CHANGELOG.md Cnct/Cnct.NetCore/Cnct.NetCore.csproj
+$schemaDir = "schema\v$newVersion"
+New-Item -ItemType Directory -Force -Path $schemaDir | Out-Null
+Copy-Item "schema\cnctConfig.vnext.json" "$schemaDir\cnctConfig.json"
+$newId = "https://raw.githubusercontent.com/bgold09/cnct-net/main/schema/v$newVersion/cnctConfig.json"
+(Get-Content "$schemaDir\cnctConfig.json") `
+    -replace '"id": "https://raw\.githubusercontent\.com/bgold09/cnct-net/develop/schema/cnctConfig\.vnext\.json"', `
+             "`"id`": `"$newId`"" |
+    Set-Content "$schemaDir\cnctConfig.json"
+```
+
+The resulting file lives at `schema/v<version>/cnctConfig.json` with an `"id"` of:
+
+```
+https://raw.githubusercontent.com/bgold09/cnct-net/main/schema/v<version>/cnctConfig.json
+```
+
+### 7. Commit the changes
+
+Stage all three files and commit with the exact message format `Release <version>`:
+
+```powershell
+git add CHANGELOG.md Cnct/Cnct.NetCore/Cnct.NetCore.csproj schema/v<version>/cnctConfig.json
 git commit -m "Release <version>"
 # e.g. git commit -m "Release 0.4.0"
 ```
 
 Do **not** include a `Co-authored-by` trailer in release commits — keep them clean.
 
-### 7. Push the branch
+### 8. Push the branch
 
 ```powershell
 git push -u origin release-<new-version>
 ```
 
-### 8. Create a pull request
+### 9. Create a pull request
 
 Create a PR from `release-<new-version>` → `release` branch:
 - **Title**: `Release <version>` (e.g. `Release 0.4.0`)
@@ -182,7 +204,7 @@ cause the command to hang in sync PowerShell sessions:
 
 The command prints the new PR URL on success (e.g. `https://github.com/bgold09/cnct-net/pull/65`).
 
-### 9. Wait for CI on PR 1 (`release-<version>` → `release`)
+### 10. Wait for CI on PR 1 (`release-<version>` → `release`)
 
 Stream CI status until all three matrix checks complete. Run in **async mode** and read output
 with `read_powershell` — this can take several minutes:
@@ -199,7 +221,7 @@ The three required checks are:
 
 If any check fails, **stop** — do not proceed to the merge step. Investigate the failure first.
 
-### 10. Merge PR 1
+### 11. Merge PR 1
 
 ```powershell
 & $gh pr merge --merge
@@ -208,7 +230,7 @@ If any check fails, **stop** — do not proceed to the merge step. Investigate t
 This merges `release-<version>` into `release`. The GitHub ruleset enforces the merge method;
 do **not** use `--squash` or `--rebase`.
 
-### 11. Create PR 2 (`release` → `main`)
+### 12. Create PR 2 (`release` → `main`)
 
 Run in **async mode** and capture the printed PR URL:
 
@@ -220,7 +242,7 @@ Run in **async mode** and capture the printed PR URL:
 The command prints the new PR URL (e.g. `https://github.com/bgold09/cnct-net/pull/66`).
 Store it as `$pr2`.
 
-### 12. Wait for CI on PR 2
+### 13. Wait for CI on PR 2
 
 ```powershell
 # async mode
@@ -230,7 +252,7 @@ Store it as `$pr2`.
 Wait for all three `build (ubuntu-latest)` / `build (windows-latest)` / `build (macos-latest)`
 checks to pass. Stop and investigate if any fail.
 
-### 13. Merge PR 2
+### 14. Merge PR 2
 
 ```powershell
 & $gh pr merge $pr2 --merge
@@ -238,7 +260,7 @@ checks to pass. Stop and investigate if any fail.
 
 Do **not** use `--squash` or `--rebase`.
 
-### 14. Create PR 3 (`main` → `develop`)
+### 15. Create PR 3 (`main` → `develop`)
 
 Run in **async mode** and capture the printed PR URL:
 
@@ -249,7 +271,7 @@ Run in **async mode** and capture the printed PR URL:
 
 Store the returned URL as `$pr3`.
 
-### 15. Wait for CI on PR 3
+### 16. Wait for CI on PR 3
 
 ```powershell
 # async mode
@@ -258,7 +280,7 @@ Store the returned URL as `$pr3`.
 
 Wait for all three matrix checks to pass. Stop and investigate if any fail.
 
-### 16. Merge PR 3
+### 17. Merge PR 3
 
 ```powershell
 & $gh pr merge $pr3 --merge
@@ -274,7 +296,8 @@ Do **not** use `--squash` or `--rebase`. This preserves full commit history on `
 - [ ] `CHANGELOG.md` updated: PR links added to each entry, unreleased items moved under new
   version heading, `## Unreleased` left empty
 - [ ] `<BaseVersion>` in `Cnct/Cnct.NetCore/Cnct.NetCore.csproj` updated
-- [ ] Both files staged and committed with message `Release <version>`
+- [ ] `schema/v<version>/cnctConfig.json` copied from vnext and `"id"` patched to versioned `main` URI
+- [ ] All three files staged and committed with message `Release <version>`
 - [ ] Branch pushed to origin
 - [ ] PR 1 created (`release-<version>` → `release`)
 - [ ] PR 1 CI passed (all three matrix checks green)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   on Linux and macOS. The `os` property on shell actions
   is now optional — when omitted, the action runs on all
   platforms.
+* Each action now logs a start (`>`) and finish (`✓`) event. An optional `"label"`
+  property can be added to actions in `cnct.json` to add context to the display.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   platforms.
 * Each action now logs a start (`>`) and finish (`✓`) event. An optional `"label"`
   property can be added to actions in `cnct.json` to add context to the display.
+* Add `--validate` / `-v` option to validate a `cnct.json` config file without executing
+  it. Results are written to stdout as JSON (`{ "valid": bool, "issues": [...] }`) so the
+  output can be consumed by scripts and CI/CD pipelines. Exit code is `0` when the config
+  is valid and `1` when there are errors. Validation checks include:
+  * `link` / `copy`: each source file or directory must exist on disk.
+  * `linkExpand`: the source directory must exist on disk.
+  * `cloneGitRepository`: each repository URL must be a valid absolute URI.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,30 @@
 
 ## Unreleased
 
+## 0.6.0
+
 ### Feature updates
 
-* The `os` property is now supported on all action types. When set, the action only runs
-  on the specified operating system(s).
-* Add `sh` shell type for running commands via `/bin/sh`
-  on Linux and macOS. The `os` property on shell actions
-  is now optional — when omitted, the action runs on all
-  platforms.
-* Each action now logs a start (`>`) and finish (`✓`) event. An optional `"label"`
-  property can be added to actions in `cnct.json` to add context to the display.
-* Add `--validate` / `-v` option to validate a `cnct.json` config file without executing
-  it. Results are written to stdout as JSON (`{ "valid": bool, "issues": [...] }`) so the
-  output can be consumed by scripts and CI/CD pipelines. Exit code is `0` when the config
-  is valid and `1` when there are errors. Validation checks include:
+* The `os` property is now supported on all action types. When set, the action
+  only runs on the specified operating system(s).
+  ([#78](https://github.com/bgold09/cnct-net/pull/78))
+* Add `sh` shell type for running commands via `/bin/sh` on Linux and macOS.
+  The `os` property on shell actions is now optional — when omitted, the action
+  runs on all platforms.
+  ([#78](https://github.com/bgold09/cnct-net/pull/78))
+* Each action now logs a start (`>`) and finish (`✓`) event. An optional
+  `"label"` property can be added to actions in `cnct.json` to add context to
+  the display.
+  ([#79](https://github.com/bgold09/cnct-net/pull/79))
+* Add `--validate` / `-v` option to validate a `cnct.json` config file without
+  executing it. Results are written to stdout as JSON
+  (`{ "valid": bool, "issues": [...] }`) so the output can be consumed by
+  scripts and CI/CD pipelines. Exit code is `0` when the config is valid and
+  `1` when there are errors. Validation checks include:
   * `link` / `copy`: each source file or directory must exist on disk.
   * `linkExpand`: the source directory must exist on disk.
   * `cloneGitRepository`: each repository URL must be a valid absolute URI.
+  ([#84](https://github.com/bgold09/cnct-net/pull/84))
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Feature updates
 
+* The `os` property is now supported on all action types. When set, the action only runs
+  on the specified operating system(s).
 * Add `sh` shell type for running commands via `/bin/sh`
   on Linux and macOS. The `os` property on shell actions
   is now optional — when omitted, the action runs on all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Feature updates
+
+* Add `sh` shell type for running commands via `/bin/sh`
+  on Linux and macOS. The `os` property on shell actions
+  is now optional — when omitted, the action runs on all
+  platforms.
+
 ## 0.5.0
 
 ### Feature updates

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -59,25 +60,30 @@ namespace Cnct.Core.Tests
         }
 
         [Fact]
-        public void Validate_ThrowsWhenReposIsNull()
+        public void Validate_ReturnsError_WhenReposIsNull()
         {
             var spec = new CloneGitRepositoryTaskSpecification { Repos = null };
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Fact]
-        public void Validate_ThrowsWhenReposIsEmpty()
+        public void Validate_ReturnsError_WhenReposIsEmpty()
         {
             var spec = new CloneGitRepositoryTaskSpecification
             {
                 Repos = new Dictionary<string, string>(),
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Fact]
-        public void Validate_DoesNotThrowWithValidSpec()
+        public void Validate_ReturnsNoErrors_WhenSpecIsValid()
         {
             var spec = new CloneGitRepositoryTaskSpecification
             {
@@ -87,14 +93,16 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            spec.Validate();
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.DoesNotContain(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Validate_ThrowsWhenEntryValueIsNullOrWhiteSpace(string dest)
+        public void Validate_ReturnsError_WhenEntryValueIsNullOrWhiteSpace(string dest)
         {
             var spec = new CloneGitRepositoryTaskSpecification
             {
@@ -104,7 +112,9 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
 
         [Fact]
@@ -261,6 +271,41 @@ namespace Cnct.Core.Tests
             var spec = new CloneGitRepositoryTaskSpecification();
 
             Assert.Equal("cloneGitRepository", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenAllUrlsAreValidAbsoluteUris()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new Dictionary<string, string>
+                {
+                    ["https://github.com/user/repo"] = "~/dev/repo",
+                    ["ssh://git@github.com/user/repo.git"] = "~/dev/repo2",
+                },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenUrlIsNotAValidAbsoluteUri()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new Dictionary<string, string>
+                {
+                    ["not a valid url"] = "~/dev/repo",
+                },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("not a valid absolute URI", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
@@ -219,6 +220,47 @@ namespace Cnct.Core.Tests
             logger.Verify(l => l.LogWarning(It.Is<string>(s => s.Contains(dest))), Times.Once);
             mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void GetDisplayText_SingleRepo_ReturnsActionTypeAndUri()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new ReadOnlyDictionary<string, string>(
+                    new Dictionary<string, string>
+                    {
+                        ["https://github.com/user/repo"] = "~/repos/repo",
+                    }),
+            };
+
+            Assert.Equal("cloneGitRepository: https://github.com/user/repo", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void GetDisplayText_MultipleRepos_ReturnsAllUris()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new ReadOnlyDictionary<string, string>(
+                    new Dictionary<string, string>
+                    {
+                        ["https://github.com/user/repo1"] = "~/repos/repo1",
+                        ["https://github.com/user/repo2"] = "~/repos/repo2",
+                    }),
+            };
+
+            Assert.Equal(
+                "cloneGitRepository: https://github.com/user/repo1, https://github.com/user/repo2",
+                spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void GetDisplayText_NullRepos_ReturnsActionType()
+        {
+            var spec = new CloneGitRepositoryTaskSpecification();
+
+            Assert.Equal("cloneGitRepository", spec.GetDisplayText());
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -237,10 +237,6 @@ namespace Cnct.Core.Tests
 
             public override string ActionType => "test";
 
-            public override void Validate()
-            {
-            }
-
             public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
             {
                 this.WasExecuted = true;

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -159,6 +159,67 @@ namespace Cnct.Core.Tests
             logger.Verify(l => l.LogStart("test"), Times.Once);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_SkipsAction_WhenOsDoesNotMatch()
+        {
+            var logger = new Mock<ILogger>();
+            var nonCurrentPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+            var action = new TestActionSpec
+            {
+                PlatformType = new[] { nonCurrentPlatform },
+            };
+            var config = new CnctConfig
+            {
+                Logger = logger.Object,
+                ConfigRootDirectory = "/",
+                MachineTags = Array.Empty<string>(),
+                Actions = new ICnctActionSpec[] { action },
+            };
+
+            await config.ExecuteAsync();
+
+            Assert.False(action.WasExecuted);
+            logger.Verify(
+                l => l.LogStart(It.IsAny<string>()),
+                Times.Never);
+            logger.Verify(
+                l => l.LogFinish(It.IsAny<string>()),
+                Times.Never);
+            logger.Verify(
+                l => l.LogVerbose(
+                    It.Is<string>(
+                        s => s.Contains("not applicable to current OS"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsAction_WhenOsMatches()
+        {
+            var action = new TestActionSpec
+            {
+                PlatformType = new[] { Platform.CurrentPlatform },
+            };
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsAction_WhenOsNotSpecified()
+        {
+            var action = new TestActionSpec();
+            var config = MakeConfig(Array.Empty<string>(), action);
+
+            await config.ExecuteAsync();
+
+            Assert.True(action.WasExecuted);
+            Assert.Null(action.PlatformType);
+        }
+
         private static CnctConfig MakeConfig(IReadOnlyCollection<string> machineTags, params ICnctActionSpec[] actions)
         {
             return new CnctConfig

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -99,6 +99,66 @@ namespace Cnct.Core.Tests
             Assert.False(taggedAction.WasExecuted);
         }
 
+        [Fact]
+        public async Task ExecuteAsync_LogsStartAndFinish_WithDisplayText()
+        {
+            var logger = new Mock<ILogger>();
+            var action = new TestActionSpec();
+            var config = new CnctConfig
+            {
+                Logger = logger.Object,
+                ConfigRootDirectory = "/",
+                MachineTags = Array.Empty<string>(),
+                Actions = new ICnctActionSpec[] { action },
+            };
+
+            await config.ExecuteAsync();
+
+            logger.Verify(l => l.LogStart("test"), Times.Once);
+            logger.Verify(
+                l => l.LogFinish(It.Is<string>(s => s.StartsWith("test"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_UsesLabel_WhenLabelIsSet()
+        {
+            var logger = new Mock<ILogger>();
+            var action = new TestActionSpec { Label = "my custom label" };
+            var config = new CnctConfig
+            {
+                Logger = logger.Object,
+                ConfigRootDirectory = "/",
+                MachineTags = Array.Empty<string>(),
+                Actions = new ICnctActionSpec[] { action },
+            };
+
+            await config.ExecuteAsync();
+
+            logger.Verify(l => l.LogStart("test: my custom label"), Times.Once);
+            logger.Verify(
+                l => l.LogFinish(It.Is<string>(s => s.StartsWith("test: my custom label"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_UsesGetDisplayText_WhenLabelIsNotSet()
+        {
+            var logger = new Mock<ILogger>();
+            var action = new TestActionSpec();
+            var config = new CnctConfig
+            {
+                Logger = logger.Object,
+                ConfigRootDirectory = "/",
+                MachineTags = Array.Empty<string>(),
+                Actions = new ICnctActionSpec[] { action },
+            };
+
+            await config.ExecuteAsync();
+
+            logger.Verify(l => l.LogStart("test"), Times.Once);
+        }
+
         private static CnctConfig MakeConfig(IReadOnlyCollection<string> machineTags, params ICnctActionSpec[] actions)
         {
             return new CnctConfig

--- a/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -32,6 +34,46 @@ namespace Cnct.Core.Tests
             var spec = new CopyTaskSpecification();
 
             Assert.Equal("copy", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenSourceExists()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "my-file";
+            string fullSourcePath = $"{configRoot}/{sourceFile}";
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(fullSourcePath, new MockFileData(string.Empty));
+
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenSourceDoesNotExist()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "missing-file";
+
+            var mockFs = new MockFileSystem();
+
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("does not exist", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
@@ -25,5 +25,13 @@ namespace Cnct.Core.Tests
             var spec = Assert.IsType<CopyTaskSpecification>(specInterface);
             Assert.Equal(expectedFileConfigs.Count, spec.Files.Count);
         }
+
+        [Fact]
+        public void GetDisplayText_ReturnsCopy()
+        {
+            var spec = new CopyTaskSpecification();
+
+            Assert.Equal("copy", spec.GetDisplayText());
+        }
     }
 }

--- a/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -37,6 +38,36 @@ namespace Cnct.Core.Tests
             };
 
             Assert.Equal("environmentVariable: 'MY_VAR=hello'", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenNameIsValid()
+        {
+            var spec = new EnvironmentVariableTaskSpecification
+            {
+                Name = "MY_VAR",
+                Value = "hello",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenNameContainsEquals()
+        {
+            var spec = new EnvironmentVariableTaskSpecification
+            {
+                Name = "MY=VAR",
+                Value = "hello",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("'='", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
@@ -26,5 +26,17 @@ namespace Cnct.Core.Tests
             Assert.Equal(expectedVarName, envVariableSpec.Name);
             Assert.Equal(expectedValue, envVariableSpec.Value);
         }
+
+        [Fact]
+        public void GetDisplayText_ReturnsNameEqualsValue()
+        {
+            var spec = new EnvironmentVariableTaskSpecification
+            {
+                Name = "MY_VAR",
+                Value = "hello",
+            };
+
+            Assert.Equal("environmentVariable: 'MY_VAR=hello'", spec.GetDisplayText());
+        }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -35,42 +36,36 @@ namespace Cnct.Core.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Validate_ThrowsWhenSourceIsNullOrWhiteSpace(string source)
+        public void Validate_ReturnsError_WhenSourceIsNullOrWhiteSpace(string source)
         {
-            var spec = new LinkExpandTaskSpecification
+            var mockFs = new MockFileSystem();
+            var spec = new LinkExpandTaskSpecification(mockFs)
             {
                 Source = source,
                 Target = "~/some/target",
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("source"));
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Validate_ThrowsWhenTargetIsNullOrWhiteSpace(string target)
+        public void Validate_ReturnsError_WhenTargetIsNullOrWhiteSpace(string target)
         {
-            var spec = new LinkExpandTaskSpecification
+            var mockFs = new MockFileSystem();
+            var spec = new LinkExpandTaskSpecification(mockFs)
             {
                 Source = "~/some/source",
                 Target = target,
             };
 
-            Assert.Throws<InvalidOperationException>(() => spec.Validate());
-        }
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
 
-        [Fact]
-        public void Validate_DoesNotThrowWithValidSpec()
-        {
-            var spec = new LinkExpandTaskSpecification
-            {
-                Source = "~/dev/scripts-pr/skills",
-                Target = "~/.github/skills",
-            };
-
-            spec.Validate();
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("target"));
         }
 
         [Fact]
@@ -104,6 +99,48 @@ namespace Cnct.Core.Tests
             var spec = new LinkExpandTaskSpecification();
 
             Assert.Equal("linkExpand", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenSourceDirectoryExists()
+        {
+            const string configRoot = "/config";
+            const string source = "my-scripts";
+            string fullSourcePath = $"{configRoot}/{source}";
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddDirectory(fullSourcePath);
+
+            var spec = new LinkExpandTaskSpecification(mockFs)
+            {
+                Source = source,
+                Target = "~/some/target",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenSourceDirectoryDoesNotExist()
+        {
+            const string configRoot = "/config";
+            const string source = "missing-scripts";
+
+            var mockFs = new MockFileSystem();
+
+            var spec = new LinkExpandTaskSpecification(mockFs)
+            {
+                Source = source,
+                Target = "~/some/target",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("does not exist", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -97,5 +97,13 @@ namespace Cnct.Core.Tests
                 l => l.LogWarning(It.Is<string>(s => s.Contains(expectedResolvedSource))),
                 Times.Once);
         }
+
+        [Fact]
+        public void GetDisplayText_ReturnsLinkExpand()
+        {
+            var spec = new LinkExpandTaskSpecification();
+
+            Assert.Equal("linkExpand", spec.GetDisplayText());
+        }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -32,6 +34,46 @@ namespace Cnct.Core.Tests
             var spec = new LinkTaskSpecification();
 
             Assert.Equal("link", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsNoIssues_WhenSourceExists()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "my-file";
+            string fullSourcePath = $"{configRoot}/{sourceFile}";
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(fullSourcePath, new MockFileData(string.Empty));
+
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenSourceDoesNotExist()
+        {
+            const string configRoot = "/config";
+            const string sourceFile = "missing-file";
+
+            var mockFs = new MockFileSystem();
+
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = new Dictionary<string, object> { [sourceFile] = "~/destination" },
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+
+            Assert.Single(issues);
+            Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
+            Assert.Contains("does not exist", issues[0].Message);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
@@ -25,5 +25,13 @@ namespace Cnct.Core.Tests
             var spec = Assert.IsType<LinkTaskSpecification>(specInterface);
             Assert.Equal(expectedLinks.Count, spec.Links.Count);
         }
+
+        [Fact]
+        public void GetDisplayText_ReturnsLink()
+        {
+            var spec = new LinkTaskSpecification();
+
+            Assert.Equal("link", spec.GetDisplayText());
+        }
     }
 }

--- a/Cnct/Cnct.Core.Tests/PowerShellInvokerTests.cs
+++ b/Cnct/Cnct.Core.Tests/PowerShellInvokerTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Cnct.Core.Tasks.Shell;
+using Moq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class PowerShellInvokerTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_ThrowsWhenSpecIsNull()
+        {
+            var invoker = new PowerShellInvoker();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => invoker.ExecuteAsync(null));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_OnNonWindows_CallsProcessRunnerWithPwsh()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var logger = new Mock<ILogger>();
+            var runner = new Mock<IProcessRunner>();
+            ProcessStartInfo captured = null;
+
+            runner.Setup(r => r.ExecuteAsync(
+                    It.IsAny<ProcessStartInfo>(),
+                    It.IsAny<ShellTaskSpecification>(),
+                    It.IsAny<ILogger>()))
+                .Callback<ProcessStartInfo,
+                    ShellTaskSpecification, ILogger>(
+                    (si, _, __) => captured = si)
+                .Returns(Task.CompletedTask);
+
+            var spec = new ShellTaskSpecification
+            {
+                Shell =
+                    ShellTaskSpecification.ShellType.PowerShell,
+                Command = "./bootstrap.ps1",
+            };
+
+            var invoker = new PowerShellInvoker(
+                logger.Object, runner.Object);
+            await invoker.ExecuteAsync(spec);
+
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ProcessStartInfo>(),
+                    spec,
+                    logger.Object),
+                Times.Once);
+
+            Assert.Equal("pwsh", captured.FileName);
+            Assert.Contains(
+                "-NoProfile", captured.ArgumentList);
+            Assert.Contains(
+                "-NoLogo", captured.ArgumentList);
+            Assert.Contains("-File", captured.ArgumentList);
+            Assert.Contains(
+                "./bootstrap.ps1", captured.ArgumentList);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SilentSpec_StillCallsRunner()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var logger = new Mock<ILogger>();
+            var runner = new Mock<IProcessRunner>();
+            runner.Setup(r => r.ExecuteAsync(
+                    It.IsAny<ProcessStartInfo>(),
+                    It.IsAny<ShellTaskSpecification>(),
+                    It.IsAny<ILogger>()))
+                .Returns(Task.CompletedTask);
+
+            var spec = new ShellTaskSpecification
+            {
+                Shell =
+                    ShellTaskSpecification.ShellType.PowerShell,
+                Command = "./script.ps1",
+                Silent = true,
+            };
+
+            var invoker = new PowerShellInvoker(
+                logger.Object, runner.Object);
+            await invoker.ExecuteAsync(spec);
+
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ProcessStartInfo>(),
+                    spec,
+                    logger.Object),
+                Times.Once);
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/ShInvokerTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShInvokerTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Cnct.Core.Tasks.Shell;
+using Moq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class ShInvokerTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_ThrowsWhenSpecIsNull()
+        {
+            var logger = new Mock<ILogger>();
+            var invoker = new ShInvoker(logger.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => invoker.ExecuteAsync(null));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CallsProcessRunnerWithShArgs()
+        {
+            var logger = new Mock<ILogger>();
+            var runner = new Mock<IProcessRunner>();
+            ProcessStartInfo captured = null;
+
+            runner.Setup(r => r.ExecuteAsync(
+                    It.IsAny<ProcessStartInfo>(),
+                    It.IsAny<ShellTaskSpecification>(),
+                    It.IsAny<ILogger>()))
+                .Callback<ProcessStartInfo,
+                    ShellTaskSpecification, ILogger>(
+                    (si, _, __) => captured = si)
+                .Returns(Task.CompletedTask);
+
+            var spec = new ShellTaskSpecification
+            {
+                Shell = ShellTaskSpecification.ShellType.Sh,
+                Command = "./bootstrap.sh",
+            };
+
+            var invoker = new ShInvoker(
+                logger.Object, runner.Object);
+            await invoker.ExecuteAsync(spec);
+
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ProcessStartInfo>(),
+                    spec,
+                    logger.Object),
+                Times.Once);
+
+            Assert.Equal("/bin/sh", captured.FileName);
+            Assert.Contains("-c", captured.ArgumentList);
+            Assert.Contains(
+                "./bootstrap.sh", captured.ArgumentList);
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -11,6 +11,8 @@ namespace Cnct.Core.Tests
         [Theory]
         [InlineData(ShellTaskSpecification.ShellType.PowerShell, "PowerShell")]
         [InlineData(ShellTaskSpecification.ShellType.PowerShell, "powershell")]
+        [InlineData(ShellTaskSpecification.ShellType.Sh, "Sh")]
+        [InlineData(ShellTaskSpecification.ShellType.Sh, "sh")]
         public void CanDeserializeShellType(
             ShellTaskSpecification.ShellType expectedShellType,
             string shellTypeStr)
@@ -82,6 +84,21 @@ namespace Cnct.Core.Tests
             var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
             var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
             Assert.Empty(spec.Tags);
+        }
+
+        [Fact]
+        public void OsIsOptional()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "shell",
+                ["shell"] = "powershell",
+                ["command"] = "echo hello",
+            });
+
+            var specInterface = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+            var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
+            Assert.Null(spec.PlatformType);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -110,7 +110,7 @@ namespace Cnct.Core.Tests
                 Command = "Install-Module foo",
             };
 
-            Assert.Equal("shell: 'PowerShell Install-Module foo'", spec.GetDisplayText());
+            Assert.Equal("shell: 'powerShell Install-Module foo'", spec.GetDisplayText());
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace Cnct.Core.Tests
                 Command = "echo hello",
             };
 
-            Assert.Equal("shell: 'Sh echo hello'", spec.GetDisplayText());
+            Assert.Equal("shell: 'sh echo hello'", spec.GetDisplayText());
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -123,6 +124,23 @@ namespace Cnct.Core.Tests
             };
 
             Assert.Equal("shell: 'sh echo hello'", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void Validate_ReturnsWarning_WhenShellNotOnPath()
+        {
+            // Use a shell type that is guaranteed not to exist on PATH under this name
+            var spec = new ShellTaskSpecification
+            {
+                Shell = ShellTaskSpecification.ShellType.PowerShell,
+                Command = "echo hello",
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+
+            // The result depends on whether pwsh is installed — just verify the shape
+            // If pwsh is not on PATH, we expect a warning; if it is, we expect no issues.
+            Assert.All(issues, i => Assert.Equal(ValidationSeverity.Warning, i.Severity));
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -100,5 +100,29 @@ namespace Cnct.Core.Tests
             var spec = Assert.IsType<ShellTaskSpecification>(specInterface);
             Assert.Null(spec.PlatformType);
         }
+
+        [Fact]
+        public void GetDisplayText_ReturnsShellAndCommand()
+        {
+            var spec = new ShellTaskSpecification
+            {
+                Shell = ShellTaskSpecification.ShellType.PowerShell,
+                Command = "Install-Module foo",
+            };
+
+            Assert.Equal("shell: 'PowerShell Install-Module foo'", spec.GetDisplayText());
+        }
+
+        [Fact]
+        public void GetDisplayText_ShellSh_ReturnsShellAndCommand()
+        {
+            var spec = new ShellTaskSpecification
+            {
+                Shell = ShellTaskSpecification.ShellType.Sh,
+                Command = "echo hello",
+            };
+
+            Assert.Equal("shell: 'Sh echo hello'", spec.GetDisplayText());
+        }
     }
 }

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -2,19 +2,21 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
+using Cnct.Core.Validation;
 
 namespace Cnct.Core
 {
     public static class CnctCommandLine
     {
-        public static async Task Invoke(string[] args)
+        public static async Task<int> Invoke(string[] args)
         {
             var rootCommand = new RootCommand
             {
                 Description = "A cross-platform bootstrapping tool. Connect your dotfiles / cnct the dots!",
-                Handler = CommandHandler.Create((Func<FileInfo, bool, bool, Task<int>>)ExecuteAsync),
+                Handler = CommandHandler.Create((Func<FileInfo, bool, bool, bool, Task<int>>)ExecuteAsync),
             };
 
             string configOptDescription = "Path to a configuration file. If not supplied, a file called 'cnct.json' "
@@ -24,6 +26,7 @@ namespace Cnct.Core
                 CreateOption<FileInfo>('c', "config", configOptDescription),
                 CreateOption<bool>('q', "quiet", "Suppress all output other than errors."),
                 CreateOption<bool>('d', "debug", "Output additional debug information."),
+                CreateOption<bool>('v', "validate", "Validate the config file and output results as JSON."),
             };
 
             foreach (var option in options)
@@ -31,10 +34,10 @@ namespace Cnct.Core
                 rootCommand.AddOption(option);
             }
 
-            await rootCommand.InvokeAsync(args);
+            return await rootCommand.InvokeAsync(args);
         }
 
-        private static async Task<int> ExecuteAsync(FileInfo config, bool quiet, bool debug)
+        private static async Task<int> ExecuteAsync(FileInfo config, bool quiet, bool debug, bool validate)
         {
             var logger = new ConsoleLogger(new LoggerOptions(quiet, debug));
             var parser = new CnctConfigurationParser(logger);
@@ -42,7 +45,24 @@ namespace Cnct.Core
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
             cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
-            cnctConfig.Validate();
+
+            ConfigValidationResult validation = cnctConfig.Validate();
+            if (validate)
+            {
+                Console.WriteLine(validation.ToJson());
+                return validation.IsValid ? 0 : 1;
+            }
+
+            if (!validation.IsValid)
+            {
+                foreach (var issue in validation.Issues.Where(i => i.Severity == ValidationSeverity.Error))
+                {
+                    logger.LogError(issue.Message);
+                }
+
+                return 1;
+            }
+
             bool result = await cnctConfig.ExecuteAsync();
 
             return result ? 0 : 1;

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -75,5 +75,10 @@ namespace Cnct.Core.Configuration
 
             return cloneTask.ExecuteAsync();
         }
+
+        protected override string GetAdditionalDisplayText() =>
+            this.Repos != null && this.Repos.Count > 0
+                ? string.Join(", ", this.Repos.Keys)
+                : null;
     }
 }

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -32,25 +33,34 @@ namespace Cnct.Core.Configuration
         [JsonProperty("repos")]
         public IReadOnlyDictionary<string, string> Repos { get; set; }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
             if (this.Repos == null || this.Repos.Count == 0)
             {
-                throw new InvalidOperationException("The collection of repositories cannot be null or empty.");
+                issues.Add(this.CreateValidationError("The collection of repositories cannot be null or empty."));
+                return issues;
             }
 
             foreach (var kvp in this.Repos)
             {
                 if (string.IsNullOrWhiteSpace(kvp.Key))
                 {
-                    throw new InvalidOperationException("Each repository entry must have a non-empty URL.");
+                    issues.Add(this.CreateValidationError("Each repository entry must have a non-empty URL."));
+                }
+                else if (!Uri.TryCreate(kvp.Key, UriKind.Absolute, out _))
+                {
+                    issues.Add(this.CreateValidationError($"Repository URL is not a valid absolute URI: {kvp.Key}"));
                 }
 
                 if (string.IsNullOrWhiteSpace(kvp.Value))
                 {
-                    throw new InvalidOperationException($"The destination path for repository '{kvp.Key}' cannot be null or empty.");
+                    issues.Add(this.CreateValidationError(
+                        $"The destination path for repository '{kvp.Key}' cannot be null or empty."));
                 }
             }
+
+            return issues;
         }
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -41,10 +42,28 @@ namespace Cnct.Core.Configuration
                 || this.PlatformType.Contains(Platform.CurrentPlatform);
         }
 
-        public abstract void Validate();
+        public virtual IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        {
+            return Array.Empty<ValidationIssue>();
+        }
 
         public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
 
+        protected ValidationIssue CreateValidationError(string message)
+        {
+            return this.CreateValidationIssue(ValidationSeverity.Error, message);
+        }
+
+        protected ValidationIssue CreateValidationWarning(string message)
+        {
+            return this.CreateValidationIssue(ValidationSeverity.Warning, message);
+        }
+
         protected virtual string GetAdditionalDisplayText() => null;
+
+        private ValidationIssue CreateValidationIssue(ValidationSeverity severity, string message)
+        {
+            return new ValidationIssue(severity, this.ActionType, this.Label, message);
+        }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -7,14 +7,27 @@ namespace Cnct.Core.Configuration
 {
     public abstract class CnctActionSpecBase : ICnctActionSpec
     {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
         [JsonProperty("tags")]
         [JsonConverter(typeof(StringCollectionConverter))]
         public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
 
         public abstract string ActionType { get; }
 
+        public virtual string GetDisplayText()
+        {
+            string extra = this.GetAdditionalDisplayText();
+            return string.IsNullOrEmpty(extra)
+                ? this.ActionType
+                : $"{this.ActionType}: {extra}";
+        }
+
         public abstract void Validate();
 
         public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
+
+        protected virtual string GetAdditionalDisplayText() => null;
     }
 }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -14,14 +15,30 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(StringCollectionConverter))]
         public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
 
+        [JsonProperty("os")]
+        [JsonConverter(typeof(EnumCollectionConverter<PlatformType>))]
+        public IReadOnlyCollection<PlatformType> PlatformType { get; set; }
+
         public abstract string ActionType { get; }
 
-        public virtual string GetDisplayText()
+        public string GetDisplayText()
         {
+            if (!string.IsNullOrEmpty(this.Label))
+            {
+                return $"{this.ActionType}: {this.Label}";
+            }
+
             string extra = this.GetAdditionalDisplayText();
             return string.IsNullOrEmpty(extra)
                 ? this.ActionType
                 : $"{this.ActionType}: {extra}";
+        }
+
+        public bool ShouldExecuteOnCurrentPlatform()
+        {
+            return this.PlatformType == null
+                || this.PlatformType.Count == 0
+                || this.PlatformType.Contains(Platform.CurrentPlatform);
         }
 
         public abstract void Validate();

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -20,12 +21,27 @@ namespace Cnct.Core.Configuration
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }
 
-        public void Validate()
+        public ConfigValidationResult Validate()
         {
-            foreach (var action in this.Actions)
+            if (this.Actions == null || this.Actions.Length == 0)
             {
-                action.Validate();
+                return new ConfigValidationResult(new[]
+                {
+                    new ValidationIssue(
+                        ValidationSeverity.Error,
+                        "config",
+                        null,
+                        "The configuration must contain at least one action."),
+                });
             }
+
+            var issues = new List<ValidationIssue>();
+            foreach (var action in this.Actions.Where(a => a != null))
+            {
+                issues.AddRange(action.Validate(this.ConfigRootDirectory));
+            }
+
+            return new ConfigValidationResult(issues);
         }
 
         public async Task<bool> ExecuteAsync()

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -40,19 +40,21 @@ namespace Cnct.Core.Configuration
                     continue;
                 }
 
+                string displayText = action is CnctActionSpecBase specBase
+                    && !string.IsNullOrEmpty(specBase.Label)
+                        ? $"{specBase.ActionType}: {specBase.Label}"
+                        : action.GetDisplayText();
+
                 try
                 {
                     var start = DateTimeOffset.Now;
-                    this.Logger.LogVerbose(
-                        $"[{start:HH:mm:ss.fff}] Starting task '{action.ActionType}'");
+                    this.Logger.LogStart(displayText);
 
-                    await action.ExecuteAsync(this.Logger, this.ConfigRootDirectory);
+                    await action.ExecuteAsync(new IndentedLogger(this.Logger), this.ConfigRootDirectory);
 
                     var end = DateTimeOffset.Now;
                     var elapsed = end - start;
-                    this.Logger.LogVerbose(
-                        $"[{end:HH:mm:ss.fff}] Finished task '{action.ActionType}'"
-                        + $" ({elapsed.TotalSeconds:F1}s)");
+                    this.Logger.LogFinish($"{displayText} ({elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)
                 {

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -42,7 +42,17 @@ namespace Cnct.Core.Configuration
 
                 try
                 {
+                    var start = DateTimeOffset.Now;
+                    this.Logger.LogVerbose(
+                        $"[{start:HH:mm:ss.fff}] Starting task '{action.ActionType}'");
+
                     await action.ExecuteAsync(this.Logger, this.ConfigRootDirectory);
+
+                    var end = DateTimeOffset.Now;
+                    var elapsed = end - start;
+                    this.Logger.LogVerbose(
+                        $"[{end:HH:mm:ss.fff}] Finished task '{action.ActionType}'"
+                        + $" ({elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)
                 {

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -32,18 +32,20 @@ namespace Cnct.Core.Configuration
         {
             foreach (var action in this.Actions.Where(a => a != null))
             {
-                if (action is CnctActionSpecBase taggedAction
-                    && taggedAction.Tags.Any()
-                    && !taggedAction.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                if (action.Tags.Any()
+                    && !action.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
                 {
                     this.Logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
                     continue;
                 }
 
-                string displayText = action is CnctActionSpecBase specBase
-                    && !string.IsNullOrEmpty(specBase.Label)
-                        ? $"{specBase.ActionType}: {specBase.Label}"
-                        : action.GetDisplayText();
+                if (!action.ShouldExecuteOnCurrentPlatform())
+                {
+                    this.Logger.LogVerbose($"Skipping action '{action.ActionType}': not applicable to current OS.");
+                    continue;
+                }
+
+                string displayText = action.GetDisplayText();
 
                 try
                 {

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 
 namespace Cnct.Core.Configuration
 {
@@ -32,12 +33,24 @@ namespace Cnct.Core.Configuration
         {
         }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
             if (this.Files == null || this.Files.Count == 0)
             {
-                throw new InvalidOperationException("The collection of files cannot be null or empty.");
+                issues.Add(this.CreateValidationError("The collection of files cannot be null or empty."));
+                return issues;
             }
+
+            foreach (string sourcePath in this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Files).Keys)
+            {
+                if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
+                {
+                    issues.Add(this.CreateValidationError($"Source path does not exist: {sourcePath}"));
+                }
+            }
+
+            return issues;
         }
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -26,5 +26,7 @@ namespace Cnct.Core.Configuration
         public override void Validate()
         {
         }
+
+        protected override string GetAdditionalDisplayText() => $"'{this.Name}={this.Value}'";
     }
 }

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.EnvironmentVariable;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -23,8 +24,16 @@ namespace Cnct.Core.Configuration
             await envVariableTask.ExecuteAsync();
         }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
+            if (!string.IsNullOrEmpty(this.Name) && this.Name.Contains('='))
+            {
+                issues.Add(this.CreateValidationError(
+                    $"Environment variable '{this.Name}' contains '=', which is not valid."));
+            }
+
+            return issues;
         }
 
         protected override string GetAdditionalDisplayText() => $"'{this.Name}={this.Value}'";

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -8,6 +8,8 @@ namespace Cnct.Core.Configuration
     {
         string ActionType { get; }
 
+        string GetDisplayText();
+
         void Validate();
 
         Task ExecuteAsync(ILogger logger, string configDirectoryRoot);

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -15,7 +16,7 @@ namespace Cnct.Core.Configuration
 
         bool ShouldExecuteOnCurrentPlatform();
 
-        void Validate();
+        IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot);
 
         Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
     }

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -8,7 +9,11 @@ namespace Cnct.Core.Configuration
     {
         string ActionType { get; }
 
+        IReadOnlyCollection<string> Tags { get; }
+
         string GetDisplayText();
+
+        bool ShouldExecuteOnCurrentPlatform();
 
         void Validate();
 

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -27,17 +29,34 @@ namespace Cnct.Core.Configuration
         [JsonProperty("target")]
         public string Target { get; set; }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
             if (string.IsNullOrWhiteSpace(this.Source))
             {
-                throw new InvalidOperationException("A source directory must be specified.");
+                issues.Add(this.CreateValidationError("A source directory must be specified."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Target))
             {
-                throw new InvalidOperationException("A target directory must be specified.");
+                issues.Add(this.CreateValidationError("A target directory must be specified."));
             }
+
+            if (issues.Count == 0)
+            {
+                string source = this.Source.NormalizePath();
+                if (!this.fileSystem.Path.IsPathRooted(source))
+                {
+                    source = this.fileSystem.Path.Combine(configDirectoryRoot, source);
+                }
+
+                if (!this.fileSystem.Directory.Exists(source))
+                {
+                    issues.Add(this.CreateValidationError($"Source directory does not exist: {source}"));
+                }
+            }
+
+            return issues;
         }
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -32,12 +33,24 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Links { get; set; }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
             if (this.Links == null || this.Links.Count == 0)
             {
-                throw new InvalidOperationException("The collection of links cannot be null or empty.");
+                issues.Add(this.CreateValidationError("The collection of links cannot be null or empty."));
+                return issues;
             }
+
+            foreach (string sourcePath in this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links).Keys)
+            {
+                if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
+                {
+                    issues.Add(this.CreateValidationError($"Source path does not exist: {sourcePath}"));
+                }
+            }
+
+            return issues;
         }
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
+using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
@@ -30,18 +32,20 @@ namespace Cnct.Core.Configuration
             await shellInvoker.ExecuteAsync(this);
         }
 
-        public override void Validate()
+        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
+            var issues = new List<ValidationIssue>();
             if (this.Shell == ShellType.Unknown)
             {
-                throw new ArgumentException(
-                    $"Shell type '{this.Shell}' not recognized.");
+                issues.Add(this.CreateValidationError($"Shell type '{this.Shell}' not recognized."));
             }
 
             if (string.IsNullOrWhiteSpace(this.Command))
             {
-                throw new ArgumentException("A command must be specified.");
+                issues.Add(this.CreateValidationError("A command must be specified."));
             }
+
+            return issues;
         }
 
         protected override string GetAdditionalDisplayText()

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -17,7 +17,6 @@ namespace Cnct.Core.Configuration
         public string Command { get; set; }
 
         [JsonProperty("os")]
-        [JsonRequired]
         [JsonConverter(typeof(EnumCollectionConverter<PlatformType>))]
         public IReadOnlyCollection<PlatformType> PlatformType { get; set; }
 
@@ -25,14 +24,16 @@ namespace Cnct.Core.Configuration
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            if (!this.PlatformType.Contains(Platform.CurrentPlatform))
+            if (this.PlatformType?.Count > 0
+                && !this.PlatformType.Contains(Platform.CurrentPlatform))
             {
                 return;
             }
 
             IShellInvoker shellInvoker = this.Shell switch
             {
-                ShellType.PowerShell => new PowerShellInvoker(),
+                ShellType.PowerShell => new PowerShellInvoker(logger),
+                ShellType.Sh => new ShInvoker(logger),
                 _ => throw new ArgumentOutOfRangeException(
                     message: $"Shell type {this.Shell} is not supported.",
                     innerException: null),
@@ -45,17 +46,13 @@ namespace Cnct.Core.Configuration
         {
             if (this.Shell == ShellType.Unknown)
             {
-                throw new ArgumentException($"Shell type '{this.Shell}' not recognized.");
+                throw new ArgumentException(
+                    $"Shell type '{this.Shell}' not recognized.");
             }
 
             if (string.IsNullOrWhiteSpace(this.Command))
             {
                 throw new ArgumentException("A command must be specified.");
-            }
-
-            if (!this.PlatformType.Any())
-            {
-                throw new ArgumentException("At least one valid OS must be specified.");
             }
         }
 
@@ -63,6 +60,7 @@ namespace Cnct.Core.Configuration
         {
             Unknown = 0,
             PowerShell,
+            Sh,
         }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -56,7 +56,12 @@ namespace Cnct.Core.Configuration
             }
         }
 
-        protected override string GetAdditionalDisplayText() => $"'{this.Shell} {this.Command}'";
+        protected override string GetAdditionalDisplayText()
+        {
+            string shellName = this.Shell.ToString();
+            string camelShell = char.ToLowerInvariant(shellName[0]) + shellName.Substring(1);
+            return $"'{camelShell} {this.Command}'";
+        }
 
         public enum ShellType
         {

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
 using Newtonsoft.Json;
@@ -16,20 +14,10 @@ namespace Cnct.Core.Configuration
         [JsonRequired]
         public string Command { get; set; }
 
-        [JsonProperty("os")]
-        [JsonConverter(typeof(EnumCollectionConverter<PlatformType>))]
-        public IReadOnlyCollection<PlatformType> PlatformType { get; set; }
-
         public bool Silent { get; set; }
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            if (this.PlatformType?.Count > 0
-                && !this.PlatformType.Contains(Platform.CurrentPlatform))
-            {
-                return;
-            }
-
             IShellInvoker shellInvoker = this.Shell switch
             {
                 ShellType.PowerShell => new PowerShellInvoker(logger),

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -56,6 +56,8 @@ namespace Cnct.Core.Configuration
             }
         }
 
+        protected override string GetAdditionalDisplayText() => $"'{this.Shell} {this.Command}'";
+
         public enum ShellType
         {
             Unknown = 0,

--- a/Cnct/Cnct.Core/ConsoleLogger.cs
+++ b/Cnct/Cnct.Core/ConsoleLogger.cs
@@ -46,7 +46,7 @@ namespace Cnct.Core
         {
             if (!this.loggerOptions.Quiet)
             {
-                LogWithColor($"▶ {message}", ConsoleColor.Cyan);
+                LogWithColor($"▶ {message}", ConsoleColor.DarkCyan);
             }
         }
 
@@ -54,7 +54,7 @@ namespace Cnct.Core
         {
             if (!this.loggerOptions.Quiet)
             {
-                LogWithColor($"✓ {message}", ConsoleColor.Green);
+                LogWithColor($"✓ {message}", ConsoleColor.DarkGreen);
             }
         }
 

--- a/Cnct/Cnct.Core/ConsoleLogger.cs
+++ b/Cnct/Cnct.Core/ConsoleLogger.cs
@@ -42,6 +42,22 @@ namespace Cnct.Core
             LogWithColor(message, ConsoleColor.Yellow);
         }
 
+        public void LogStart(string message)
+        {
+            if (!this.loggerOptions.Quiet)
+            {
+                LogWithColor($"▶ {message}", ConsoleColor.Cyan);
+            }
+        }
+
+        public void LogFinish(string message)
+        {
+            if (!this.loggerOptions.Quiet)
+            {
+                LogWithColor($"✓ {message}", ConsoleColor.Green);
+            }
+        }
+
         private static void LogWithColor(string message, ConsoleColor foregroundColor)
         {
             Console.ForegroundColor = foregroundColor;

--- a/Cnct/Cnct.Core/ILogger.cs
+++ b/Cnct/Cnct.Core/ILogger.cs
@@ -13,5 +13,9 @@ namespace Cnct.Core
         void LogWarning(string message);
 
         void LogError(string message, Exception exception = null);
+
+        void LogStart(string message);
+
+        void LogFinish(string message);
     }
 }

--- a/Cnct/Cnct.Core/IndentedLogger.cs
+++ b/Cnct/Cnct.Core/IndentedLogger.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Cnct.Core
+{
+    internal class IndentedLogger : ILogger
+    {
+        private const string Indent = "  ";
+        private readonly ILogger inner;
+
+        public IndentedLogger(ILogger inner)
+        {
+            this.inner = inner;
+        }
+
+        public void LogInformation(string message) =>
+            this.inner.LogInformation($"{Indent}{message}");
+
+        public void LogVerbose(string message) =>
+            this.inner.LogVerbose($"{Indent}{message}");
+
+        public void LogWarning(string message) =>
+            this.inner.LogWarning(message);
+
+        public void LogError(string message, Exception exception = null) =>
+            this.inner.LogError(message, exception);
+
+        public void LogStart(string message) =>
+            this.inner.LogStart(message);
+
+        public void LogFinish(string message) =>
+            this.inner.LogFinish(message);
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/Shell/DefaultProcessRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/DefaultProcessRunner.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    public class DefaultProcessRunner : IProcessRunner
+    {
+        public async Task ExecuteAsync(
+            ProcessStartInfo startInfo,
+            ShellTaskSpecification specification,
+            ILogger logger)
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"Failed to start {startInfo.FileName}.");
+
+            var stderr = new StringBuilder();
+
+            if (!specification.Silent)
+            {
+                process.OutputDataReceived += (_, e) =>
+                {
+                    if (!string.IsNullOrEmpty(e.Data))
+                    {
+                        logger.LogInformation(e.Data);
+                    }
+                };
+            }
+
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null)
+                {
+                    stderr.AppendLine(e.Data);
+                    if (!specification.Silent)
+                    {
+                        logger.LogWarning(e.Data);
+                    }
+                }
+            };
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+            {
+                string errorOutput = stderr.Length > 0
+                    ? stderr.ToString().TrimEnd()
+                    : "(no stderr output)";
+                throw new InvalidOperationException(
+                    $"Command failed (exit code "
+                    + $"{process.ExitCode}): "
+                    + errorOutput);
+            }
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/Shell/IProcessRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/IProcessRunner.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    public interface IProcessRunner
+    {
+        Task ExecuteAsync(
+            ProcessStartInfo startInfo,
+            ShellTaskSpecification specification,
+            ILogger logger);
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/Shell/PowerShellInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/PowerShellInvoker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
@@ -9,46 +10,86 @@ namespace Cnct.Core.Tasks.Shell
 {
     public class PowerShellInvoker : IShellInvoker
     {
-        private static readonly InitialSessionState SessionState = InitialSessionState.CreateDefault();
+        private readonly ILogger logger;
+        private readonly IProcessRunner processRunner;
 
-        public async Task ExecuteAsync(ShellTaskSpecification specification)
+        public PowerShellInvoker(ILogger logger = null)
+            : this(logger, new DefaultProcessRunner())
+        {
+        }
+
+        public PowerShellInvoker(
+            ILogger logger, IProcessRunner processRunner)
+        {
+            this.logger = logger;
+            this.processRunner = processRunner;
+        }
+
+        public async Task ExecuteAsync(
+            ShellTaskSpecification specification)
         {
             if (specification == null)
             {
-                throw new ArgumentNullException(nameof(specification));
+                throw new ArgumentNullException(
+                    nameof(specification));
             }
 
-            // need this to be configurable
-            SessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
+            if (OperatingSystem.IsWindows())
+            {
+                await ExecuteInProcessAsync(specification);
+            }
+            else
+            {
+                await this.ExecuteAsProcessAsync(specification);
+            }
+        }
 
-            using var powershell = PowerShell.Create(SessionState);
+        private static async Task ExecuteInProcessAsync(
+            ShellTaskSpecification specification)
+        {
+            var sessionState =
+                InitialSessionState.CreateDefault2();
+            sessionState.ExecutionPolicy =
+                Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
+
+            using var powershell =
+                PowerShell.Create(sessionState);
             powershell.AddScript(specification.Command);
 
-            powershell.Streams.Error.DataAdded += ToStandardError<ErrorRecord>;
-            powershell.Streams.Warning.DataAdded += ToStandardOutput<WarningRecord>;
+            powershell.Streams.Error.DataAdded +=
+                ToStandardError<ErrorRecord>;
+            powershell.Streams.Warning.DataAdded +=
+                ToStandardOutput<WarningRecord>;
             if (!specification.Silent)
             {
-                powershell.Streams.Information.DataAdded += ToStandardOutput<InformationRecord>;
+                powershell.Streams.Information.DataAdded +=
+                    ToStandardOutput<InformationRecord>;
             }
 
             await powershell.InvokeAsync();
             if (powershell.HadErrors)
             {
-                throw new InvalidOperationException("command failed");
+                throw new InvalidOperationException(
+                    "command failed");
             }
         }
 
-        private static void ToStandardError<T>(object sender, DataAddedEventArgs args)
+        private static void ToStandardError<T>(
+            object sender, DataAddedEventArgs args)
         {
             ToStream<T>(sender, args, Console.Error);
         }
 
-        private static void ToStandardOutput<T>(object sender, DataAddedEventArgs args)
+        private static void ToStandardOutput<T>(
+            object sender, DataAddedEventArgs args)
         {
             ToStream<T>(sender, args, Console.Out);
         }
 
-        private static void ToStream<T>(object sender, DataAddedEventArgs args, TextWriter writer)
+        private static void ToStream<T>(
+            object sender,
+            DataAddedEventArgs args,
+            TextWriter writer)
         {
             if (!(sender is PSDataCollection<T> collection))
             {
@@ -56,6 +97,26 @@ namespace Cnct.Core.Tasks.Shell
             }
 
             writer.WriteLine(collection[args.Index]);
+        }
+
+        private async Task ExecuteAsProcessAsync(
+            ShellTaskSpecification specification)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "pwsh",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-NoLogo");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(specification.Command);
+
+            await this.processRunner.ExecuteAsync(
+                startInfo, specification, this.logger);
         }
     }
 }

--- a/Cnct/Cnct.Core/Tasks/Shell/ShInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShInvoker.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    public class ShInvoker : IShellInvoker
+    {
+        private readonly ILogger logger;
+        private readonly IProcessRunner processRunner;
+
+        public ShInvoker(ILogger logger)
+            : this(logger, new DefaultProcessRunner())
+        {
+        }
+
+        public ShInvoker(
+            ILogger logger, IProcessRunner processRunner)
+        {
+            this.logger = logger;
+            this.processRunner = processRunner;
+        }
+
+        public async Task ExecuteAsync(
+            ShellTaskSpecification specification)
+        {
+            if (specification == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(specification));
+            }
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "/bin/sh",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(specification.Command);
+
+            await this.processRunner.ExecuteAsync(
+                startInfo, specification, this.logger);
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
+++ b/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cnct.Core.Validation
+{
+    public class ConfigValidationResult
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        };
+
+        public ConfigValidationResult(IReadOnlyList<ValidationIssue> issues)
+        {
+            this.Issues = issues;
+        }
+
+        [JsonPropertyName("valid")]
+        public bool IsValid => this.Issues.All(i => i.Severity != ValidationSeverity.Error);
+
+        [JsonPropertyName("issues")]
+        public IReadOnlyList<ValidationIssue> Issues { get; }
+
+        public string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
+    }
+}

--- a/Cnct/Cnct.Core/Validation/ValidationIssue.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationIssue.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Cnct.Core.Validation
+{
+    public class ValidationIssue
+    {
+        public ValidationIssue(ValidationSeverity severity, string actionType, string label, string message)
+        {
+            this.Severity = severity;
+            this.ActionType = actionType;
+            this.Label = label;
+            this.Message = message;
+        }
+
+        [JsonPropertyName("severity")]
+        public ValidationSeverity Severity { get; }
+
+        [JsonPropertyName("actionType")]
+        public string ActionType { get; }
+
+        [JsonPropertyName("label")]
+        public string Label { get; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; }
+    }
+}

--- a/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
+++ b/Cnct/Cnct.Core/Validation/ValidationSeverity.cs
@@ -1,0 +1,9 @@
+namespace Cnct.Core.Validation
+{
+    public enum ValidationSeverity
+    {
+        None = 0,
+        Error,
+        Warning,
+    }
+}

--- a/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
+++ b/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cnct</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <BaseVersion>0.5.0</BaseVersion>
+    <BaseVersion>0.6.0</BaseVersion>
     <Version Condition=" '$(BuildNumber)' == '' ">$(BaseVersion)</Version>
     <Version Condition=" '$(BuildNumber)' != '' ">$(BaseVersion)-$(BuildNumber)</Version>
     <Authors>bgold09</Authors>

--- a/Cnct/Cnct.NetCore/Program.cs
+++ b/Cnct/Cnct.NetCore/Program.cs
@@ -5,9 +5,9 @@ namespace Cnct
 {
     public static class Program
     {
-        public static async Task Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            await CnctCommandLine.Invoke(args);
+            return await CnctCommandLine.Invoke(args);
         }
     }
 }

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -36,6 +36,14 @@
         }
     }, 
     "definitions": {
+        "OperatingSystemType": {
+            "type": "string",
+            "enum": [
+                "windows",
+                "linux",
+                "osx"
+            ]
+        },
         "ActionBase": {
             "type": "object",
             "required": [
@@ -43,12 +51,18 @@
             ],
             "properties": {
                 "os": {
-                    "description": "The operating system for which to execute the action.",
-                    "type": "string",
-                    "enum": [
-                        "windows",
-                        "linux",
-                        "osx"
+                    "description": "The operating system(s) for which to execute the action. If omitted, the action runs on all platforms.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OperatingSystemType"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OperatingSystemType"
+                            },
+                            "minItems": 1
+                        }
                     ]
                 },
                 "actionType": {

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -59,6 +59,10 @@
                     "description": "A description for the action.",
                     "type": "string"
                 },
+                "label": {
+                    "description": "An optional display label shown when the action starts and finishes. Overrides the default display format for the action type.",
+                    "type": "string"
+                },
                 "tags": {
                     "description": "Machine tags required for this action to run. If omitted or empty, the action runs on all machines. If specified, the action only runs when the machine's settings.json includes at least one matching tag.",
                     "oneOf": [

--- a/schema/v0.6.0/cnctConfig.json
+++ b/schema/v0.6.0/cnctConfig.json
@@ -1,0 +1,331 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://raw.githubusercontent.com/bgold09/cnct-net/main/schema/v0.6.0/cnctConfig.json",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "actions": {
+            "description": "The actions to execute.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/ShellAction"
+                    },
+                    {
+                        "$ref": "#/definitions/LinkAction"
+                    },
+                    {
+                        "$ref": "#/definitions/CopyAction"
+                    },
+                    {
+                        "$ref": "#/definitions/EnvironmentVariableAction"
+                    },
+                    {
+                        "$ref": "#/definitions/LinkExpandAction"
+                    },
+                    {
+                        "$ref": "#/definitions/CloneGitRepositoryAction"
+                    }
+                ]
+            }
+        }
+    }, 
+    "definitions": {
+        "OperatingSystemType": {
+            "type": "string",
+            "enum": [
+                "windows",
+                "linux",
+                "osx"
+            ]
+        },
+        "ActionBase": {
+            "type": "object",
+            "required": [
+                "actionType"
+            ],
+            "properties": {
+                "os": {
+                    "description": "The operating system(s) for which to execute the action. If omitted, the action runs on all platforms.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OperatingSystemType"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OperatingSystemType"
+                            },
+                            "minItems": 1
+                        }
+                    ]
+                },
+                "actionType": {
+                    "description": "The type of the action.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description for the action.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "An optional display label shown when the action starts and finishes. Overrides the default display format for the action type.",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Machine tags required for this action to run. If omitted or empty, the action runs on all machines. If specified, the action only runs when the machine's settings.json includes at least one matching tag.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "DestinationLinks": {
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "PlatformLinks": {
+            "type": "object",
+            "properties": {
+                "windows": {
+                    "description": "Symlinks to create in a Windows environment.",
+                    "$ref": "#/definitions/DestinationLinks"
+                },
+                "linux": {
+                    "description": "Symlinks to create in a Linux environment.",
+                    "$ref": "#/definitions/DestinationLinks"
+                },
+                "osx": {
+                    "description": "Symlinks to create in an OSX environment.",
+                    "$ref": "#/definitions/DestinationLinks"
+                },
+                "unix": {
+                    "description": "Symlinks to create in a UNIX environment.",
+                    "$ref": "#/definitions/DestinationLinks"
+                }
+            }
+        },
+        "ShellAction": {
+            "description": "An action that invokes a command or script in a shell.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "command"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "shell"
+                            ]
+                        },
+                        "command": {
+                            "description": "The command to invoke.",
+                            "type": "string"
+                        },
+                        "shell": {
+                            "description": "The type of shell to use when invoking the command.",
+                            "enum": [
+                                "sh",
+                                "powershell"
+                            ]
+                        },
+                        "silent": {
+                            "description": "If true, do not direct output from the shell to the console.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "LinkAction": {
+            "allOf":[
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "links"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "link"
+                            ]
+                        },
+                        "links": {
+                            "description": "The target and destination for symlinks to create.",
+                            "type": "object", 
+                            "minItems": 1,
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/definitions/DestinationLinks"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/PlatformLinks"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "CopyAction": {
+            "allOf":[
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "files"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "copy"
+                            ]
+                        },
+                        "files": {
+                            "description": "The target and destination for files to copy.",
+                            "type": "object",
+                            "minItems": 1,
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/definitions/DestinationLinks"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/PlatformLinks"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "EnvironmentVariableAction": {
+            "description": "Set an environment variable.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "environmentVariable"
+                            ]
+                        },
+                        "name": {
+                            "description": "The name of the environment variable to set.",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the environment variable to set.",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "LinkExpandAction": {
+            "description": "An action that creates individual symlinks for each subdirectory of a source directory into a target directory.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "source",
+                        "target"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "linkExpand"
+                            ]
+                        },
+                        "source": {
+                            "description": "The directory whose subdirectories will be symlinked.",
+                            "type": "string"
+                        },
+                        "target": {
+                            "description": "The directory in which to create the symlinks.",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "CloneGitRepositoryAction": {
+            "description": "An action that clones git repositories and keeps them up to date.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ActionBase"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "repos"
+                    ],
+                    "properties": {
+                        "actionType": {
+                            "enum": [
+                                "cloneGitRepository"
+                            ]
+                        },
+                        "repos": {
+                            "description": "A map of repository URLs to local destination paths.",
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## 0.6.0

### Feature updates

* The `os` property is now supported on all action types ([#78](https://github.com/bgold09/cnct-net/pull/78))
* Add `sh` shell type for running commands via `/bin/sh` ([#78](https://github.com/bgold09/cnct-net/pull/78))
* Each action now logs a start and finish event with optional `label` ([#79](https://github.com/bgold09/cnct-net/pull/79))
* Add `--validate` / `-v` option for config validation ([#84](https://github.com/bgold09/cnct-net/pull/84))