### PR TITLE
refactor: centralise path resolution into IPathResolver

### DIFF
--- a/Cnct/Cnct.Core.Tests/PathResolverTests.cs
+++ b/Cnct/Cnct.Core.Tests/PathResolverTests.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using Cnct.Core.Configuration;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class PathResolverTests
+    {
+        [Fact]
+        public void Resolve_AbsolutePath_ReturnedAsIsAfterNormalization()
+        {
+            var mockFs = new MockFileSystem();
+            var resolver = new PathResolver(mockFs);
+
+            string absolutePath = Path.Combine(
+                Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar),
+                "some",
+                "path");
+
+            string result = resolver.Resolve(absolutePath, "/config");
+
+            Assert.Equal(absolutePath, result);
+        }
+
+        [Fact]
+        public void Resolve_RelativePath_CombinedWithConfigRoot()
+        {
+            var mockFs = new MockFileSystem();
+            var resolver = new PathResolver(mockFs);
+
+            const string configRoot = "/config";
+            string relativePath = $"sub{Path.DirectorySeparatorChar}dir";
+            string expected = mockFs.Path.Combine(configRoot, relativePath);
+
+            string result = resolver.Resolve(relativePath, configRoot);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Resolve_TildePrefixedPath_ExpandsHomeDirectory()
+        {
+            var mockFs = new MockFileSystem();
+            var resolver = new PathResolver(mockFs);
+
+            string result = resolver.Resolve("~/my/dir", "/config");
+
+            string expected = $"{Platform.Home}{Path.DirectorySeparatorChar}my{Path.DirectorySeparatorChar}dir";
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -13,10 +13,12 @@ namespace Cnct.Core.Configuration
     {
         private readonly IFileSystem fileSystem;
         private readonly IGitRunner gitRunner;
+        private readonly IPathResolver pathResolver;
 
         public CloneGitRepositoryTaskSpecification()
         {
             this.fileSystem = new FileSystem();
+            this.pathResolver = new PathResolver(this.fileSystem);
         }
 
         public CloneGitRepositoryTaskSpecification(IGitRunner gitRunner)
@@ -24,10 +26,21 @@ namespace Cnct.Core.Configuration
         {
         }
 
-        public CloneGitRepositoryTaskSpecification(IGitRunner gitRunner, IFileSystem fileSystem)
+        public CloneGitRepositoryTaskSpecification(
+            IGitRunner gitRunner,
+            IFileSystem fileSystem)
+            : this(gitRunner, fileSystem, new PathResolver(fileSystem))
+        {
+        }
+
+        public CloneGitRepositoryTaskSpecification(
+            IGitRunner gitRunner,
+            IFileSystem fileSystem,
+            IPathResolver pathResolver)
         {
             this.gitRunner = gitRunner;
             this.fileSystem = fileSystem;
+            this.pathResolver = pathResolver;
         }
 
         [JsonProperty("repos")]
@@ -68,13 +81,9 @@ namespace Cnct.Core.Configuration
             var normalizedRepos = new Dictionary<string, string>();
             foreach (var kvp in this.Repos)
             {
-                string dest = kvp.Value.NormalizePath();
-                if (!this.fileSystem.Path.IsPathRooted(dest))
-                {
-                    dest = this.fileSystem.Path.Combine(configDirectoryRoot, dest);
-                }
-
-                normalizedRepos[kvp.Key] = dest;
+                normalizedRepos[kvp.Key] = this.pathResolver.Resolve(
+                    kvp.Value,
+                    configDirectoryRoot);
             }
 
             var cloneTask = new CloneGitRepositoryTask(

--- a/Cnct/Cnct.Core/Configuration/FileManagement.cs
+++ b/Cnct/Cnct.Core/Configuration/FileManagement.cs
@@ -7,6 +7,18 @@ namespace Cnct.Core.Configuration
 {
     public class FileManagement : IFileManagement
     {
+        private readonly IPathResolver pathResolver;
+
+        public FileManagement()
+            : this(new PathResolver())
+        {
+        }
+
+        public FileManagement(IPathResolver pathResolver)
+        {
+            this.pathResolver = pathResolver;
+        }
+
         public IDictionary<string, IEnumerable<string>> GetFileConfigurations(
             string configDirectoryRoot,
             IReadOnlyDictionary<string, object> fileConfigs)
@@ -14,7 +26,7 @@ namespace Cnct.Core.Configuration
             var fileCopyConfigs = new Dictionary<string, IEnumerable<string>>();
             foreach (var kvp in fileConfigs)
             {
-                string sourceFile = PathExtensions.NormalizePath($"{configDirectoryRoot}{Path.DirectorySeparatorChar}{kvp.Key}");
+                string sourceFile = this.pathResolver.Resolve(kvp.Key, configDirectoryRoot);
                 object destination = kvp.Value;
                 switch (destination)
                 {

--- a/Cnct/Cnct.Core/Configuration/IPathResolver.cs
+++ b/Cnct/Cnct.Core/Configuration/IPathResolver.cs
@@ -1,0 +1,7 @@
+namespace Cnct.Core.Configuration
+{
+    public interface IPathResolver
+    {
+        string Resolve(string path, string configDirectoryRoot);
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -12,15 +12,25 @@ namespace Cnct.Core.Configuration
     public sealed partial class LinkExpandTaskSpecification : CnctActionSpecBase
     {
         private readonly IFileSystem fileSystem;
+        private readonly IPathResolver pathResolver;
 
         public LinkExpandTaskSpecification()
         {
             this.fileSystem = new FileSystem();
+            this.pathResolver = new PathResolver(this.fileSystem);
         }
 
         public LinkExpandTaskSpecification(IFileSystem fileSystem)
+            : this(fileSystem, new PathResolver(fileSystem))
+        {
+        }
+
+        public LinkExpandTaskSpecification(
+            IFileSystem fileSystem,
+            IPathResolver pathResolver)
         {
             this.fileSystem = fileSystem;
+            this.pathResolver = pathResolver;
         }
 
         [JsonProperty("source")]
@@ -44,12 +54,7 @@ namespace Cnct.Core.Configuration
 
             if (issues.Count == 0)
             {
-                string source = this.Source.NormalizePath();
-                if (!this.fileSystem.Path.IsPathRooted(source))
-                {
-                    source = this.fileSystem.Path.Combine(configDirectoryRoot, source);
-                }
-
+                string source = this.pathResolver.Resolve(this.Source, configDirectoryRoot);
                 if (!this.fileSystem.Directory.Exists(source))
                 {
                     issues.Add(this.CreateValidationError($"Source directory does not exist: {source}"));
@@ -61,12 +66,7 @@ namespace Cnct.Core.Configuration
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            string source = this.Source.NormalizePath();
-            if (!this.fileSystem.Path.IsPathRooted(source))
-            {
-                source = this.fileSystem.Path.Combine(configDirectoryRoot, source);
-            }
-
+            string source = this.pathResolver.Resolve(this.Source, configDirectoryRoot);
             string target = this.Target.NormalizePath();
             var linkExpandTask = new LinkExpandTask(logger, source, target, this.fileSystem);
             return linkExpandTask.ExecuteAsync();

--- a/Cnct/Cnct.Core/Configuration/PathResolver.cs
+++ b/Cnct/Cnct.Core/Configuration/PathResolver.cs
@@ -1,0 +1,30 @@
+using System.IO.Abstractions;
+
+namespace Cnct.Core.Configuration
+{
+    public class PathResolver : IPathResolver
+    {
+        private readonly IFileSystem fileSystem;
+
+        public PathResolver()
+            : this(new FileSystem())
+        {
+        }
+
+        public PathResolver(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public string Resolve(string path, string configDirectoryRoot)
+        {
+            string result = path.NormalizePath();
+            if (!this.fileSystem.Path.IsPathRooted(result))
+            {
+                result = this.fileSystem.Path.Combine(configDirectoryRoot, result);
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Phase 2 — Extract IPathResolver

Centralises the repeated normalise-path, check-if-rooted, combine-with-configDirectoryRoot pattern into a single `IPathResolver` / `PathResolver` service.

### Changes
- **`IPathResolver`** — new interface: `string Resolve(string path, string configDirectoryRoot)`
- **`PathResolver`** — composes `NormalizePath()` + `IsPathRooted` + `Path.Combine`; takes `IFileSystem` for testability
- **`CloneGitRepositoryTaskSpecification`** — uses `IPathResolver` in `ExecuteAsync` (replacing inline logic)
- **`LinkExpandTaskSpecification`** — uses `IPathResolver` in both `Validate` and `ExecuteAsync`
- **`FileManagement`** — uses `IPathResolver` (replacing manual string concatenation)
- **`PathResolverTests`** — covers absolute, relative, and `~`-prefixed paths

### Testing
- 0 warnings, 100/100 tests pass (3 new)
- Part of separation-of-responsibilities refactoring (Phase 2 of 8)