### PR TITLE
refactor: extract IShellInvokerFactory from ShellTaskSpecification

### DIFF
--- a/Cnct/Cnct.Core.Tests/ShellInvokerFactoryTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellInvokerFactoryTests.cs
@@ -1,0 +1,40 @@
+using System;
+using Cnct.Core.Tasks.Shell;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class ShellInvokerFactoryTests
+    {
+        private readonly ShellInvokerFactory factory = new ShellInvokerFactory();
+
+        [Fact]
+        public void Create_PowerShell_ReturnsPowerShellInvoker()
+        {
+            IShellInvoker invoker = this.factory.Create(
+                Configuration.ShellTaskSpecification.ShellType.PowerShell,
+                null);
+
+            Assert.IsType<PowerShellInvoker>(invoker);
+        }
+
+        [Fact]
+        public void Create_Sh_ReturnsShInvoker()
+        {
+            IShellInvoker invoker = this.factory.Create(
+                Configuration.ShellTaskSpecification.ShellType.Sh,
+                null);
+
+            Assert.IsType<ShInvoker>(invoker);
+        }
+
+        [Fact]
+        public void Create_Unknown_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => this.factory.Create(
+                    Configuration.ShellTaskSpecification.ShellType.Unknown,
+                    null));
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -10,6 +10,18 @@ namespace Cnct.Core.Configuration
     [CnctActionType("shell")]
     public partial class ShellTaskSpecification : CnctActionSpecBase
     {
+        private readonly IShellInvokerFactory shellInvokerFactory;
+
+        public ShellTaskSpecification()
+            : this(new ShellInvokerFactory())
+        {
+        }
+
+        public ShellTaskSpecification(IShellInvokerFactory shellInvokerFactory)
+        {
+            this.shellInvokerFactory = shellInvokerFactory;
+        }
+
         [JsonRequired]
         public ShellType Shell { get; set; }
 
@@ -20,15 +32,7 @@ namespace Cnct.Core.Configuration
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            IShellInvoker shellInvoker = this.Shell switch
-            {
-                ShellType.PowerShell => new PowerShellInvoker(logger),
-                ShellType.Sh => new ShInvoker(logger),
-                _ => throw new ArgumentOutOfRangeException(
-                    message: $"Shell type {this.Shell} is not supported.",
-                    innerException: null),
-            };
-
+            IShellInvoker shellInvoker = this.shellInvokerFactory.Create(this.Shell, logger);
             await shellInvoker.ExecuteAsync(this);
         }
 

--- a/Cnct/Cnct.Core/Tasks/Shell/IShellInvokerFactory.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/IShellInvokerFactory.cs
@@ -1,0 +1,9 @@
+using static Cnct.Core.Configuration.ShellTaskSpecification;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    public interface IShellInvokerFactory
+    {
+        IShellInvoker Create(ShellType shellType, ILogger logger);
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellInvokerFactory.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellInvokerFactory.cs
@@ -1,0 +1,21 @@
+using System;
+using static Cnct.Core.Configuration.ShellTaskSpecification;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    public class ShellInvokerFactory : IShellInvokerFactory
+    {
+        public IShellInvoker Create(ShellType shellType, ILogger logger)
+        {
+            return shellType switch
+            {
+                ShellType.PowerShell => new PowerShellInvoker(logger),
+                ShellType.Sh => new ShInvoker(logger),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(shellType),
+                    shellType,
+                    $"Shell type {shellType} is not supported."),
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Phase 3 — Extract IShellInvokerFactory

Moves the `ShellType` to concrete-invoker switch expression from `ShellTaskSpecification.ExecuteAsync()` into an `IShellInvokerFactory` / `ShellInvokerFactory`.

### Changes
- **`IShellInvokerFactory`** — new interface: `IShellInvoker Create(ShellType, ILogger)`
- **`ShellInvokerFactory`** — contains the switch expression previously in `ExecuteAsync`
- **`ShellTaskSpecification`** — accepts `IShellInvokerFactory` via constructor; parameterless ctor defaults to `ShellInvokerFactory`
- **`ShellInvokerFactoryTests`** — covers PowerShell, Sh, and Unknown cases

### Testing
- 0 warnings, 100/100 tests pass (3 new)
- Part of separation-of-responsibilities refactoring (Phase 3 of 8)