### PR TITLE
refactor: decouple DefaultProcessRunner from ShellTaskSpecification

### DIFF
--- a/Cnct/Cnct.Core.Tests/PowerShellInvokerTests.cs
+++ b/Cnct/Cnct.Core.Tests/PowerShellInvokerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 using Cnct.Core.Tasks.Shell;
 using Moq;
 using Xunit;
@@ -11,7 +10,7 @@ namespace Cnct.Core.Tests
     public class PowerShellInvokerTests
     {
         [Fact]
-        public async Task ExecuteAsync_ThrowsWhenSpecIsNull()
+        public async Task ExecuteAsync_ThrowsWhenOptionsIsNull()
         {
             var invoker = new PowerShellInvoker();
 
@@ -33,28 +32,24 @@ namespace Cnct.Core.Tests
 
             runner.Setup(r => r.ExecuteAsync(
                     It.IsAny<ProcessStartInfo>(),
-                    It.IsAny<ShellTaskSpecification>(),
+                    It.IsAny<ShellExecutionOptions>(),
                     It.IsAny<ILogger>()))
                 .Callback<ProcessStartInfo,
-                    ShellTaskSpecification, ILogger>(
+                    ShellExecutionOptions, ILogger>(
                     (si, _, __) => captured = si)
                 .Returns(Task.CompletedTask);
 
-            var spec = new ShellTaskSpecification
-            {
-                Shell =
-                    ShellTaskSpecification.ShellType.PowerShell,
-                Command = "./bootstrap.ps1",
-            };
+            var options = new ShellExecutionOptions(
+                "./bootstrap.ps1", silent: false);
 
             var invoker = new PowerShellInvoker(
                 logger.Object, runner.Object);
-            await invoker.ExecuteAsync(spec);
+            await invoker.ExecuteAsync(options);
 
             runner.Verify(
                 r => r.ExecuteAsync(
                     It.IsAny<ProcessStartInfo>(),
-                    spec,
+                    options,
                     logger.Object),
                 Times.Once);
 
@@ -69,7 +64,7 @@ namespace Cnct.Core.Tests
         }
 
         [Fact]
-        public async Task ExecuteAsync_SilentSpec_StillCallsRunner()
+        public async Task ExecuteAsync_SilentOptions_StillCallsRunner()
         {
             if (OperatingSystem.IsWindows())
             {
@@ -80,26 +75,21 @@ namespace Cnct.Core.Tests
             var runner = new Mock<IProcessRunner>();
             runner.Setup(r => r.ExecuteAsync(
                     It.IsAny<ProcessStartInfo>(),
-                    It.IsAny<ShellTaskSpecification>(),
+                    It.IsAny<ShellExecutionOptions>(),
                     It.IsAny<ILogger>()))
                 .Returns(Task.CompletedTask);
 
-            var spec = new ShellTaskSpecification
-            {
-                Shell =
-                    ShellTaskSpecification.ShellType.PowerShell,
-                Command = "./script.ps1",
-                Silent = true,
-            };
+            var options = new ShellExecutionOptions(
+                "./script.ps1", silent: true);
 
             var invoker = new PowerShellInvoker(
                 logger.Object, runner.Object);
-            await invoker.ExecuteAsync(spec);
+            await invoker.ExecuteAsync(options);
 
             runner.Verify(
                 r => r.ExecuteAsync(
                     It.IsAny<ProcessStartInfo>(),
-                    spec,
+                    options,
                     logger.Object),
                 Times.Once);
         }

--- a/Cnct/Cnct.Core.Tests/ShInvokerTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShInvokerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 using Cnct.Core.Tasks.Shell;
 using Moq;
 using Xunit;
@@ -11,7 +10,7 @@ namespace Cnct.Core.Tests
     public class ShInvokerTests
     {
         [Fact]
-        public async Task ExecuteAsync_ThrowsWhenSpecIsNull()
+        public async Task ExecuteAsync_ThrowsWhenOptionsIsNull()
         {
             var logger = new Mock<ILogger>();
             var invoker = new ShInvoker(logger.Object);
@@ -29,27 +28,24 @@ namespace Cnct.Core.Tests
 
             runner.Setup(r => r.ExecuteAsync(
                     It.IsAny<ProcessStartInfo>(),
-                    It.IsAny<ShellTaskSpecification>(),
+                    It.IsAny<ShellExecutionOptions>(),
                     It.IsAny<ILogger>()))
                 .Callback<ProcessStartInfo,
-                    ShellTaskSpecification, ILogger>(
+                    ShellExecutionOptions, ILogger>(
                     (si, _, __) => captured = si)
                 .Returns(Task.CompletedTask);
 
-            var spec = new ShellTaskSpecification
-            {
-                Shell = ShellTaskSpecification.ShellType.Sh,
-                Command = "./bootstrap.sh",
-            };
+            var options = new ShellExecutionOptions(
+                "./bootstrap.sh", silent: false);
 
             var invoker = new ShInvoker(
                 logger.Object, runner.Object);
-            await invoker.ExecuteAsync(spec);
+            await invoker.ExecuteAsync(options);
 
             runner.Verify(
                 r => r.ExecuteAsync(
                     It.IsAny<ProcessStartInfo>(),
-                    spec,
+                    options,
                     logger.Object),
                 Times.Once);
 

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -32,8 +32,18 @@ namespace Cnct.Core.Configuration
 
         public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            IShellInvoker shellInvoker = this.shellInvokerFactory.Create(this.Shell, logger);
-            await shellInvoker.ExecuteAsync(this);
+            IShellInvoker shellInvoker = this.Shell switch
+            {
+                ShellType.PowerShell => new PowerShellInvoker(logger),
+                ShellType.Sh => new ShInvoker(logger),
+                _ => throw new ArgumentOutOfRangeException(
+                    message: $"Shell type {this.Shell} is not supported.",
+                    innerException: null),
+            };
+
+            var options = new ShellExecutionOptions(
+                this.Command, this.Silent);
+            await shellInvoker.ExecuteAsync(options);
         }
 
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -41,8 +41,7 @@ namespace Cnct.Core.Configuration
                     innerException: null),
             };
 
-            var options = new ShellExecutionOptions(
-                this.Command, this.Silent);
+            var options = new ShellExecutionOptions(this.Command, this.Silent);
             await shellInvoker.ExecuteAsync(options);
         }
 

--- a/Cnct/Cnct.Core/Tasks/Shell/DefaultProcessRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/DefaultProcessRunner.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.Shell
 {
@@ -10,7 +9,7 @@ namespace Cnct.Core.Tasks.Shell
     {
         public async Task ExecuteAsync(
             ProcessStartInfo startInfo,
-            ShellTaskSpecification specification,
+            ShellExecutionOptions options,
             ILogger logger)
         {
             using var process = Process.Start(startInfo)
@@ -19,7 +18,7 @@ namespace Cnct.Core.Tasks.Shell
 
             var stderr = new StringBuilder();
 
-            if (!specification.Silent)
+            if (!options.Silent)
             {
                 process.OutputDataReceived += (_, e) =>
                 {
@@ -35,7 +34,7 @@ namespace Cnct.Core.Tasks.Shell
                 if (e.Data != null)
                 {
                     stderr.AppendLine(e.Data);
-                    if (!specification.Silent)
+                    if (!options.Silent)
                     {
                         logger.LogWarning(e.Data);
                     }

--- a/Cnct/Cnct.Core/Tasks/Shell/IProcessRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/IProcessRunner.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.Shell
 {
@@ -8,7 +7,7 @@ namespace Cnct.Core.Tasks.Shell
     {
         Task ExecuteAsync(
             ProcessStartInfo startInfo,
-            ShellTaskSpecification specification,
+            ShellExecutionOptions options,
             ILogger logger);
     }
 }

--- a/Cnct/Cnct.Core/Tasks/Shell/IShellInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/IShellInvoker.cs
@@ -1,10 +1,9 @@
 ﻿using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.Shell
 {
     public interface IShellInvoker
     {
-        Task ExecuteAsync(ShellTaskSpecification specification);
+        Task ExecuteAsync(ShellExecutionOptions options);
     }
 }

--- a/Cnct/Cnct.Core/Tasks/Shell/PowerShellInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/PowerShellInvoker.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.Shell
 {
@@ -26,26 +25,26 @@ namespace Cnct.Core.Tasks.Shell
         }
 
         public async Task ExecuteAsync(
-            ShellTaskSpecification specification)
+            ShellExecutionOptions options)
         {
-            if (specification == null)
+            if (options == null)
             {
                 throw new ArgumentNullException(
-                    nameof(specification));
+                    nameof(options));
             }
 
             if (OperatingSystem.IsWindows())
             {
-                await ExecuteInProcessAsync(specification);
+                await ExecuteInProcessAsync(options);
             }
             else
             {
-                await this.ExecuteAsProcessAsync(specification);
+                await this.ExecuteAsProcessAsync(options);
             }
         }
 
         private static async Task ExecuteInProcessAsync(
-            ShellTaskSpecification specification)
+            ShellExecutionOptions options)
         {
             var sessionState =
                 InitialSessionState.CreateDefault2();
@@ -54,13 +53,13 @@ namespace Cnct.Core.Tasks.Shell
 
             using var powershell =
                 PowerShell.Create(sessionState);
-            powershell.AddScript(specification.Command);
+            powershell.AddScript(options.Command);
 
             powershell.Streams.Error.DataAdded +=
                 ToStandardError<ErrorRecord>;
             powershell.Streams.Warning.DataAdded +=
                 ToStandardOutput<WarningRecord>;
-            if (!specification.Silent)
+            if (!options.Silent)
             {
                 powershell.Streams.Information.DataAdded +=
                     ToStandardOutput<InformationRecord>;
@@ -100,7 +99,7 @@ namespace Cnct.Core.Tasks.Shell
         }
 
         private async Task ExecuteAsProcessAsync(
-            ShellTaskSpecification specification)
+            ShellExecutionOptions options)
         {
             var startInfo = new ProcessStartInfo
             {
@@ -113,10 +112,10 @@ namespace Cnct.Core.Tasks.Shell
             startInfo.ArgumentList.Add("-NoProfile");
             startInfo.ArgumentList.Add("-NoLogo");
             startInfo.ArgumentList.Add("-File");
-            startInfo.ArgumentList.Add(specification.Command);
+            startInfo.ArgumentList.Add(options.Command);
 
             await this.processRunner.ExecuteAsync(
-                startInfo, specification, this.logger);
+                startInfo, options, this.logger);
         }
     }
 }

--- a/Cnct/Cnct.Core/Tasks/Shell/ShInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShInvoker.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.Shell
 {
@@ -23,12 +22,12 @@ namespace Cnct.Core.Tasks.Shell
         }
 
         public async Task ExecuteAsync(
-            ShellTaskSpecification specification)
+            ShellExecutionOptions options)
         {
-            if (specification == null)
+            if (options == null)
             {
                 throw new ArgumentNullException(
-                    nameof(specification));
+                    nameof(options));
             }
 
             var startInfo = new ProcessStartInfo
@@ -40,10 +39,10 @@ namespace Cnct.Core.Tasks.Shell
             };
 
             startInfo.ArgumentList.Add("-c");
-            startInfo.ArgumentList.Add(specification.Command);
+            startInfo.ArgumentList.Add(options.Command);
 
             await this.processRunner.ExecuteAsync(
-                startInfo, specification, this.logger);
+                startInfo, options, this.logger);
         }
     }
 }

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellExecutionOptions.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellExecutionOptions.cs
@@ -7,9 +7,7 @@ namespace Cnct.Core.Tasks.Shell
         public ShellExecutionOptions(
             string command, bool silent)
         {
-            this.Command = command
-                ?? throw new ArgumentNullException(
-                    nameof(command));
+            this.Command = command ?? throw new ArgumentNullException(nameof(command));
             this.Silent = silent;
         }
 

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellExecutionOptions.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellExecutionOptions.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    public class ShellExecutionOptions
+    {
+        public ShellExecutionOptions(
+            string command, bool silent)
+        {
+            this.Command = command
+                ?? throw new ArgumentNullException(
+                    nameof(command));
+            this.Silent = silent;
+        }
+
+        public string Command { get; }
+
+        public bool Silent { get; }
+    }
+}


### PR DESCRIPTION
## Phase 4 — Decouple DefaultProcessRunner

Replaces the `ShellTaskSpecification` parameter in `IProcessRunner` / `DefaultProcessRunner` with a slim `ShellExecutionOptions` data class, breaking the back-reference from `Tasks/Shell` to `Configuration`.

### Changes
- **`ShellExecutionOptions`** — new class with `Command` and `Silent` properties (with null validation)
- **`IProcessRunner`** — signature uses `ShellExecutionOptions` instead of `ShellTaskSpecification`
- **`DefaultProcessRunner`** — updated to use `options.Silent`
- **`IShellInvoker`** — signature uses `ShellExecutionOptions` instead of `ShellTaskSpecification`
- **`PowerShellInvoker`** / **`ShInvoker`** — create `ShellExecutionOptions` from spec properties
- All `using Cnct.Core.Configuration` imports removed from Shell layer files
- Tests updated to use new types

### Testing
- 0 warnings, 97/97 tests pass
- Part of separation-of-responsibilities refactoring (Phase 4 of 8)