### PR TITLE
refactor: extract IPlatformPathSelector from FileManagement

### DIFF
--- a/Cnct/Cnct.Core.Tests/PlatformPathSelectorTests.cs
+++ b/Cnct/Cnct.Core.Tests/PlatformPathSelectorTests.cs
@@ -1,0 +1,79 @@
+using System;
+using Cnct.Core.Configuration;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class PlatformPathSelectorTests
+    {
+        [Fact]
+        public void GetPlatformPathsReturnsCurrentPlatformPaths()
+        {
+            var selector = new PlatformPathSelector();
+            var spec = new FileSpecification
+            {
+                Windows = new[] { @"C:\Users\test\file" },
+                Linux = new[] { "/home/test/file" },
+                Osx = new[] { "/Users/test/file" },
+            };
+
+            string[] result = selector.GetPlatformPaths(spec);
+
+            string[] expected = Platform.CurrentPlatform switch
+            {
+                PlatformType.Windows => spec.Windows,
+                PlatformType.Linux => spec.Linux,
+                PlatformType.OSX => spec.Osx,
+                _ => throw new NotImplementedException(),
+            };
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void GetPlatformPathsReturnsNullWhenPlatformNotSet()
+        {
+            var selector = new PlatformPathSelector();
+            var spec = new FileSpecification();
+
+            string[] result = selector.GetPlatformPaths(spec);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetUnixPathsReturnsUnixProperty()
+        {
+            var selector = new PlatformPathSelector();
+            var spec = new FileSpecification
+            {
+                Unix = new[] { "/home/test/file" },
+            };
+
+            string[] result = selector.GetUnixPaths(spec);
+
+            Assert.Equal(spec.Unix, result);
+        }
+
+        [Fact]
+        public void GetUnixPathsReturnsNullWhenNotSet()
+        {
+            var selector = new PlatformPathSelector();
+            var spec = new FileSpecification();
+
+            string[] result = selector.GetUnixPaths(spec);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void IsCurrentPlatformUnixMatchesPlatform()
+        {
+            var selector = new PlatformPathSelector();
+
+            Assert.Equal(
+                Platform.CurrentPlatformIsUnix,
+                selector.IsCurrentPlatformUnix);
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/FileManagement.cs
+++ b/Cnct/Cnct.Core/Configuration/FileManagement.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -8,15 +7,24 @@ namespace Cnct.Core.Configuration
     public class FileManagement : IFileManagement
     {
         private readonly IPathResolver pathResolver;
+        private readonly IPlatformPathSelector platformPathSelector;
 
         public FileManagement()
-            : this(new PathResolver())
+            : this(new PathResolver(), new PlatformPathSelector())
         {
         }
 
         public FileManagement(IPathResolver pathResolver)
+            : this(pathResolver, new PlatformPathSelector())
+        {
+        }
+
+        public FileManagement(
+            IPathResolver pathResolver,
+            IPlatformPathSelector platformPathSelector)
         {
             this.pathResolver = pathResolver;
+            this.platformPathSelector = platformPathSelector;
         }
 
         public IDictionary<string, IEnumerable<string>> GetFileConfigurations(
@@ -39,13 +47,8 @@ namespace Cnct.Core.Configuration
                         break;
 
                     case FileSpecification spec:
-                        string[] platformLinkPaths = Platform.CurrentPlatform switch
-                        {
-                            PlatformType.Windows => spec.Windows,
-                            PlatformType.Linux => spec.Linux,
-                            PlatformType.OSX => spec.Osx,
-                            _ => throw new NotImplementedException(),
-                        };
+                        string[] platformLinkPaths =
+                            this.platformPathSelector.GetPlatformPaths(spec);
 
                         string[] destinationPaths;
                         if (TryGetPlatformLinkPaths(sourceFile, platformLinkPaths, out destinationPaths))
@@ -53,7 +56,11 @@ namespace Cnct.Core.Configuration
                             fileCopyConfigs.Add(sourceFile, destinationPaths);
                         }
 
-                        if (Platform.CurrentPlatformIsUnix && TryGetPlatformLinkPaths(sourceFile, spec.Unix, out destinationPaths))
+                        if (this.platformPathSelector.IsCurrentPlatformUnix
+                            && TryGetPlatformLinkPaths(
+                                sourceFile,
+                                this.platformPathSelector.GetUnixPaths(spec),
+                                out destinationPaths))
                         {
                             fileCopyConfigs.Add(sourceFile, destinationPaths);
                         }

--- a/Cnct/Cnct.Core/Configuration/IPlatformPathSelector.cs
+++ b/Cnct/Cnct.Core/Configuration/IPlatformPathSelector.cs
@@ -1,0 +1,11 @@
+namespace Cnct.Core.Configuration
+{
+    public interface IPlatformPathSelector
+    {
+        string[] GetPlatformPaths(FileSpecification spec);
+
+        string[] GetUnixPaths(FileSpecification spec);
+
+        bool IsCurrentPlatformUnix { get; }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/PlatformPathSelector.cs
+++ b/Cnct/Cnct.Core/Configuration/PlatformPathSelector.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Cnct.Core.Configuration
+{
+    public class PlatformPathSelector : IPlatformPathSelector
+    {
+        public bool IsCurrentPlatformUnix => Platform.CurrentPlatformIsUnix;
+
+        public string[] GetPlatformPaths(FileSpecification spec)
+        {
+            return Platform.CurrentPlatform switch
+            {
+                PlatformType.Windows => spec.Windows,
+                PlatformType.Linux => spec.Linux,
+                PlatformType.OSX => spec.Osx,
+                _ => throw new NotImplementedException(),
+            };
+        }
+
+        public string[] GetUnixPaths(FileSpecification spec)
+        {
+            return spec.Unix;
+        }
+    }
+}


### PR DESCRIPTION
## Phase 5: Split FileManagement responsibilities

### Goal
Extract platform-specific path selection from `FileManagement` into a dedicated `IPlatformPathSelector` interface, making `FileManagement` a thin coordinator.

### Changes
- **New** `IPlatformPathSelector.cs` — interface for platform-specific destination selection from `FileSpecification`
- **New** `PlatformPathSelector.cs` — production implementation using `Platform.CurrentPlatform` switch
- **Updated** `FileManagement.cs` — accepts `IPlatformPathSelector` via constructor, delegates platform path logic
- **New** `PlatformPathSelectorTests.cs` — unit tests for the selector

### Pattern
`FileManagement` keeps its public API but internally delegates to `IPathResolver` (Phase 2) and `IPlatformPathSelector` (this phase). Each extracted service has a single responsibility.

### Verification
- 0 warnings, 108 tests pass