### PR TITLE
refactor: deduplicate path resolution in spec validation and execution

### DIFF
--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -78,13 +78,7 @@ namespace Cnct.Core.Configuration
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            var normalizedRepos = new Dictionary<string, string>();
-            foreach (var kvp in this.Repos)
-            {
-                normalizedRepos[kvp.Key] = this.pathResolver.Resolve(
-                    kvp.Value,
-                    configDirectoryRoot);
-            }
+            var normalizedRepos = this.ResolveRepoPaths(configDirectoryRoot);
 
             var cloneTask = new CloneGitRepositoryTask(
                 logger,
@@ -99,5 +93,19 @@ namespace Cnct.Core.Configuration
             this.Repos != null && this.Repos.Count > 0
                 ? string.Join(", ", this.Repos.Keys)
                 : null;
+
+        private Dictionary<string, string> ResolveRepoPaths(
+            string configDirectoryRoot)
+        {
+            var resolved = new Dictionary<string, string>();
+            foreach (var kvp in this.Repos)
+            {
+                resolved[kvp.Key] = this.pathResolver.Resolve(
+                    kvp.Value,
+                    configDirectoryRoot);
+            }
+
+            return resolved;
+        }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -54,10 +54,11 @@ namespace Cnct.Core.Configuration
 
             if (issues.Count == 0)
             {
-                string source = this.pathResolver.Resolve(this.Source, configDirectoryRoot);
+                string source = this.ResolveSourcePath(configDirectoryRoot);
                 if (!this.fileSystem.Directory.Exists(source))
                 {
-                    issues.Add(this.CreateValidationError($"Source directory does not exist: {source}"));
+                    issues.Add(this.CreateValidationError(
+                        $"Source directory does not exist: {source}"));
                 }
             }
 
@@ -66,10 +67,13 @@ namespace Cnct.Core.Configuration
 
         public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
         {
-            string source = this.pathResolver.Resolve(this.Source, configDirectoryRoot);
+            string source = this.ResolveSourcePath(configDirectoryRoot);
             string target = this.Target.NormalizePath();
             var linkExpandTask = new LinkExpandTask(logger, source, target, this.fileSystem);
             return linkExpandTask.ExecuteAsync();
         }
+
+        private string ResolveSourcePath(string configDirectoryRoot) =>
+            this.pathResolver.Resolve(this.Source, configDirectoryRoot);
     }
 }


### PR DESCRIPTION
## Phase 7: Deduplicate validation vs. execution path logic

### Goal
Eliminate duplicated `IPathResolver.Resolve()` calls that appear in both `Validate()` and `ExecuteAsync()` of two spec classes.

### Changes
- **`CloneGitRepositoryTaskSpecification`** — extracted `ResolveRepoPaths(configDirectoryRoot)` private helper; both `Validate()` and `ExecuteAsync()` can call it (currently only `ExecuteAsync` does, since `Validate` doesn't resolve paths)
- **`LinkExpandTaskSpecification`** — extracted `ResolveSourcePath(configDirectoryRoot)` private helper called from both `Validate()` and `ExecuteAsync()`

### Why this matters
When the same path resolution logic is written twice, the two copies can drift apart over time. A shared helper ensures consistency and reduces the risk of divergence.

### Verification
- 0 warnings, 103 tests pass