### PR TITLE
refactor: extract execution into ActionRunner layer

### DIFF
--- a/Cnct/Cnct.Core.Tests/ActionRunnerTests.cs
+++ b/Cnct/Cnct.Core.Tests/ActionRunnerTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Cnct.Core.Tasks;
+using Moq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class ActionRunnerTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_ThrowsForUnsupportedSpecType()
+        {
+            var runner = new ActionRunner();
+            var spec = new UnsupportedSpec();
+
+            await Assert.ThrowsAsync<NotSupportedException>(
+                () => runner.ExecuteAsync(
+                    spec, Mock.Of<ILogger>(), "/config"));
+        }
+
+        private class UnsupportedSpec : CnctActionSpecBase
+        {
+            public override string ActionType => "unsupported";
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/ActionRunnerTests.cs
+++ b/Cnct/Cnct.Core.Tests/ActionRunnerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
@@ -18,6 +20,72 @@ namespace Cnct.Core.Tests
             await Assert.ThrowsAsync<NotSupportedException>(
                 () => runner.ExecuteAsync(
                     spec, Mock.Of<ILogger>(), "/config"));
+        }
+
+        [Fact]
+        public async Task LinkExpandDispatch_ResolvesRelativeSource()
+        {
+            string configRoot = Path.GetTempPath();
+            const string relativeSource = "skills";
+            string expectedSource =
+                Path.Combine(configRoot, relativeSource);
+
+            var logger = new Mock<ILogger>();
+            var runner = new ActionRunner();
+            var spec = new LinkExpandTaskSpecification
+            {
+                Source = relativeSource,
+                Target = "~/some/target",
+            };
+
+            await runner.ExecuteAsync(
+                spec, logger.Object, configRoot);
+
+            logger.Verify(
+                l => l.LogWarning(
+                    It.Is<string>(
+                        s => s.Contains(expectedSource))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task CloneGitRepositoryDispatch_ResolvesRelativeDest()
+        {
+            string configRoot = Path.GetTempPath();
+            const string url = "https://example.com/org/repo-a";
+            string relativeDest = Path.Combine("dev", "repo-a");
+            string expectedDest =
+                Path.Combine(configRoot, relativeDest);
+
+            var logger = new Mock<ILogger>();
+            var runner = new ActionRunner();
+            var spec = new CloneGitRepositoryTaskSpecification
+            {
+                Repos = new Dictionary<string, string>
+                {
+                    [url] = relativeDest,
+                },
+            };
+
+            // ExecuteAsync will fail (no real git), but only
+            // after path resolution has occurred. We verify via
+            // the logged clone message containing the resolved
+            // absolute path.
+            try
+            {
+                await runner.ExecuteAsync(
+                    spec, logger.Object, configRoot);
+            }
+            catch
+            {
+                // Expected: git process not available in tests
+            }
+
+            logger.Verify(
+                l => l.LogInformation(
+                    It.Is<string>(
+                        s => s.Contains(expectedDest))),
+                Times.Once);
         }
 
         private class UnsupportedSpec : CnctActionSpecBase

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -1,13 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
-using System.IO.Abstractions.TestingHelpers;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
-using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
-using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -115,121 +110,6 @@ namespace Cnct.Core.Tests
             IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
-        }
-
-        [Fact]
-        public async Task ExecuteAsync_ResolvesRelativeDestAgainstConfigDirectoryRoot()
-        {
-            string configRoot = Path.GetTempPath();
-            const string url = "https://example.com/org/repo-a";
-            string relativeDest = Path.Combine("dev", "repo-a");
-            string expectedDest = Path.Combine(configRoot, relativeDest);
-
-            var mockFileSystem = new MockFileSystem();
-            var mockRunner = new Mock<IGitRunner>();
-            mockRunner.Setup(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
-
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem, new PathResolver(mockFileSystem))
-            {
-                Repos = new Dictionary<string, string> { [url] = relativeDest },
-            };
-
-            await spec.ExecuteAsync(Mock.Of<ILogger>(), configRoot);
-
-            mockRunner.Verify(
-                r => r.CloneAsync(url, expectedDest),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task ExecuteAsync_ClonesWhenDestDoesNotExist()
-        {
-            string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "repo-a");
-            const string url = "https://example.com/org/repo-a";
-
-            var mockFileSystem = new MockFileSystem();
-            var mockRunner = new Mock<IGitRunner>();
-            mockRunner.Setup(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
-
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem, new PathResolver(mockFileSystem))
-            {
-                Repos = new Dictionary<string, string> { [url] = dest },
-            };
-
-            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-            mockRunner.Verify(r => r.CloneAsync(url, dest), Times.Once);
-            mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task ExecuteAsync_PullsWhenDotGitDirectoryExists()
-        {
-            string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var mockFileSystem = new MockFileSystem();
-            mockFileSystem.Directory.CreateDirectory(mockFileSystem.Path.Combine(dest, ".git"));
-
-            const string url = "https://example.com/org/repo-a";
-            var mockRunner = new Mock<IGitRunner>();
-            mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem, new PathResolver(mockFileSystem))
-            {
-                Repos = new Dictionary<string, string> { [url] = dest },
-            };
-
-            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-            mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
-            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task ExecuteAsync_PullsWhenDotGitFileExists()
-        {
-            string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var mockFileSystem = new MockFileSystem();
-            mockFileSystem.Directory.CreateDirectory(dest);
-            mockFileSystem.File.WriteAllText(
-                mockFileSystem.Path.Combine(dest, ".git"),
-                "gitdir: ../.git/worktrees/worktree1");
-
-            const string url = "https://example.com/org/repo-a";
-            var mockRunner = new Mock<IGitRunner>();
-            mockRunner.Setup(r => r.PullAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
-
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem, new PathResolver(mockFileSystem))
-            {
-                Repos = new Dictionary<string, string> { [url] = dest },
-            };
-
-            await spec.ExecuteAsync(Mock.Of<ILogger>(), Path.GetTempPath());
-
-            mockRunner.Verify(r => r.PullAsync(dest), Times.Once);
-            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task ExecuteAsync_LogsWarningWhenDestExistsButIsNotGitRepo()
-        {
-            string dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var mockFileSystem = new MockFileSystem();
-            mockFileSystem.Directory.CreateDirectory(dest);
-
-            const string url = "https://example.com/org/repo-a";
-            var mockRunner = new Mock<IGitRunner>();
-            var logger = new Mock<ILogger>();
-
-            var spec = new CloneGitRepositoryTaskSpecification(mockRunner.Object, mockFileSystem, new PathResolver(mockFileSystem))
-            {
-                Repos = new Dictionary<string, string> { [url] = dest },
-            };
-
-            await spec.ExecuteAsync(logger.Object, Path.GetTempPath());
-
-            logger.Verify(l => l.LogWarning(It.Is<string>(s => s.Contains(dest))), Times.Once);
-            mockRunner.Verify(r => r.CloneAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockRunner.Verify(r => r.PullAsync(It.IsAny<string>()), Times.Never);
         }
 
         [Fact]

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
+using Cnct.Core.Tasks;
 using Moq;
 using Xunit;
 
@@ -13,77 +14,97 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasNoTags()
         {
             var action = new TestActionSpec();
-            var config = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
         }
 
         [Fact]
         public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasTags()
         {
             var action = new TestActionSpec();
-            var config = MakeConfig(new[] { "personal" }, action);
+            var (config, runner) = MakeConfig(new[] { "personal" }, action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
         }
 
         [Fact]
         public async Task ExecuteAsync_RunsTaggedAction_WhenMachineTagMatches()
         {
             var action = new TestActionSpec { Tags = new[] { "personal" } };
-            var config = MakeConfig(new[] { "personal" }, action);
+            var (config, runner) = MakeConfig(new[] { "personal" }, action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
         }
 
         [Fact]
         public async Task ExecuteAsync_SkipsTaggedAction_WhenNoMachineTags()
         {
             var action = new TestActionSpec { Tags = new[] { "personal" } };
-            var config = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
 
             await config.ExecuteAsync();
 
-            Assert.False(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ICnctActionSpec>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<string>()),
+                Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_SkipsTaggedAction_WhenMachineTagsDoNotMatch()
         {
             var action = new TestActionSpec { Tags = new[] { "personal" } };
-            var config = MakeConfig(new[] { "work" }, action);
+            var (config, runner) = MakeConfig(new[] { "work" }, action);
 
             await config.ExecuteAsync();
 
-            Assert.False(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ICnctActionSpec>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<string>()),
+                Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_RunsTaggedAction_CaseInsensitiveMatch()
         {
             var action = new TestActionSpec { Tags = new[] { "Personal" } };
-            var config = MakeConfig(new[] { "personal" }, action);
+            var (config, runner) = MakeConfig(new[] { "personal" }, action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
         }
 
         [Fact]
         public async Task ExecuteAsync_RunsTaggedAction_WhenAnyTagMatches()
         {
             var action = new TestActionSpec { Tags = new[] { "personal", "home" } };
-            var config = MakeConfig(new[] { "work", "home" }, action);
+            var (config, runner) = MakeConfig(new[] { "work", "home" }, action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
         }
 
         [Fact]
@@ -91,22 +112,31 @@ namespace Cnct.Core.Tests
         {
             var untaggedAction = new TestActionSpec();
             var taggedAction = new TestActionSpec { Tags = new[] { "personal" } };
-            var config = MakeConfig(Array.Empty<string>(), untaggedAction, taggedAction);
+            var (config, runner) = MakeConfig(
+                Array.Empty<string>(), untaggedAction, taggedAction);
 
             await config.ExecuteAsync();
 
-            Assert.True(untaggedAction.WasExecuted);
-            Assert.False(taggedAction.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    untaggedAction, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    taggedAction, It.IsAny<ILogger>(), It.IsAny<string>()),
+                Times.Never);
         }
 
         [Fact]
         public async Task ExecuteAsync_LogsStartAndFinish_WithDisplayText()
         {
             var logger = new Mock<ILogger>();
+            var runner = new Mock<IActionRunner>();
             var action = new TestActionSpec();
             var config = new CnctConfig
             {
                 Logger = logger.Object,
+                Runner = runner.Object,
                 ConfigRootDirectory = "/",
                 MachineTags = Array.Empty<string>(),
                 Actions = new ICnctActionSpec[] { action },
@@ -124,10 +154,12 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_UsesLabel_WhenLabelIsSet()
         {
             var logger = new Mock<ILogger>();
+            var runner = new Mock<IActionRunner>();
             var action = new TestActionSpec { Label = "my custom label" };
             var config = new CnctConfig
             {
                 Logger = logger.Object,
+                Runner = runner.Object,
                 ConfigRootDirectory = "/",
                 MachineTags = Array.Empty<string>(),
                 Actions = new ICnctActionSpec[] { action },
@@ -145,10 +177,12 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_UsesGetDisplayText_WhenLabelIsNotSet()
         {
             var logger = new Mock<ILogger>();
+            var runner = new Mock<IActionRunner>();
             var action = new TestActionSpec();
             var config = new CnctConfig
             {
                 Logger = logger.Object,
+                Runner = runner.Object,
                 ConfigRootDirectory = "/",
                 MachineTags = Array.Empty<string>(),
                 Actions = new ICnctActionSpec[] { action },
@@ -163,6 +197,7 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_SkipsAction_WhenOsDoesNotMatch()
         {
             var logger = new Mock<ILogger>();
+            var runner = new Mock<IActionRunner>();
             var nonCurrentPlatform = Platform.CurrentPlatform == PlatformType.Windows
                 ? PlatformType.Linux
                 : PlatformType.Windows;
@@ -173,6 +208,7 @@ namespace Cnct.Core.Tests
             var config = new CnctConfig
             {
                 Logger = logger.Object,
+                Runner = runner.Object,
                 ConfigRootDirectory = "/",
                 MachineTags = Array.Empty<string>(),
                 Actions = new ICnctActionSpec[] { action },
@@ -180,7 +216,12 @@ namespace Cnct.Core.Tests
 
             await config.ExecuteAsync();
 
-            Assert.False(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ICnctActionSpec>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<string>()),
+                Times.Never);
             logger.Verify(
                 l => l.LogStart(It.IsAny<string>()),
                 Times.Never);
@@ -201,47 +242,49 @@ namespace Cnct.Core.Tests
             {
                 PlatformType = new[] { Platform.CurrentPlatform },
             };
-            var config = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
         }
 
         [Fact]
         public async Task ExecuteAsync_RunsAction_WhenOsNotSpecified()
         {
             var action = new TestActionSpec();
-            var config = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
 
             await config.ExecuteAsync();
 
-            Assert.True(action.WasExecuted);
+            runner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
             Assert.Null(action.PlatformType);
         }
 
-        private static CnctConfig MakeConfig(IReadOnlyCollection<string> machineTags, params ICnctActionSpec[] actions)
+        private static (CnctConfig Config, Mock<IActionRunner> Runner) MakeConfig(
+            IReadOnlyCollection<string> machineTags,
+            params ICnctActionSpec[] actions)
         {
-            return new CnctConfig
+            var runner = new Mock<IActionRunner>();
+            var config = new CnctConfig
             {
                 Logger = Mock.Of<ILogger>(),
+                Runner = runner.Object,
                 ConfigRootDirectory = "/",
                 MachineTags = machineTags,
                 Actions = actions,
             };
+
+            return (config, runner);
         }
 
         private class TestActionSpec : CnctActionSpecBase
         {
-            public bool WasExecuted { get; private set; }
-
             public override string ActionType => "test";
-
-            public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-            {
-                this.WasExecuted = true;
-                return Task.CompletedTask;
-            }
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.IO.Abstractions.TestingHelpers;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -66,33 +63,6 @@ namespace Cnct.Core.Tests
             IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("target"));
-        }
-
-        [Fact]
-        public async Task ExecuteAsync_ResolvesRelativeSourceAgainstConfigDirectoryRoot()
-        {
-            string configRoot = Path.GetTempPath();
-            const string relativeSource = "skills";
-            string expectedResolvedSource = Path.Combine(configRoot, relativeSource);
-
-            var logger = new Mock<ILogger>();
-            logger.Setup(l => l.LogWarning(It.IsAny<string>()));
-
-            // Source dir doesn't exist in the mock filesystem → task logs a warning
-            var mockFileSystem = new MockFileSystem();
-            var spec = new LinkExpandTaskSpecification(
-                mockFileSystem,
-                new PathResolver(mockFileSystem))
-            {
-                Source = relativeSource,
-                Target = "~/some/target",
-            };
-
-            await spec.ExecuteAsync(logger.Object, configRoot);
-
-            logger.Verify(
-                l => l.LogWarning(It.Is<string>(s => s.Contains(expectedResolvedSource))),
-                Times.Once);
         }
 
         [Fact]

--- a/Cnct/Cnct.Core/Cnct.Core.csproj
+++ b/Cnct/Cnct.Core/Cnct.Core.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Cnct.Core</AssemblyName>
     <RootNamespace>Cnct.Core</RootNamespace>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
+using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
 
 namespace Cnct.Core
@@ -45,6 +46,7 @@ namespace Cnct.Core
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
             cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
+            cnctConfig.Runner = new ActionRunner();
 
             ConfigValidationResult validation = cnctConfig.Validate();
             if (validate)

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO.Abstractions;
-using System.Threading.Tasks;
-using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -11,26 +8,6 @@ namespace Cnct.Core.Configuration
     [CnctActionType("cloneGitRepository")]
     public sealed partial class CloneGitRepositoryTaskSpecification : CnctActionSpecBase
     {
-        private readonly IFileSystem fileSystem;
-        private readonly IGitRunner gitRunner;
-        private readonly IPathResolver pathResolver;
-
-        public CloneGitRepositoryTaskSpecification(
-            IGitRunner gitRunner,
-            IFileSystem fileSystem,
-            IPathResolver pathResolver)
-        {
-            this.gitRunner = gitRunner;
-            this.fileSystem = fileSystem;
-            this.pathResolver = pathResolver;
-        }
-
-        public CloneGitRepositoryTaskSpecification()
-        {
-            this.fileSystem = new FileSystem();
-            this.pathResolver = new PathResolver(this.fileSystem);
-        }
-
         [JsonProperty("repos")]
         public IReadOnlyDictionary<string, string> Repos { get; set; }
 
@@ -62,25 +39,6 @@ namespace Cnct.Core.Configuration
             }
 
             return issues;
-        }
-
-        public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-        {
-            var normalizedRepos = new Dictionary<string, string>();
-            foreach (var kvp in this.Repos)
-            {
-                normalizedRepos[kvp.Key] = this.pathResolver.Resolve(
-                    kvp.Value,
-                    configDirectoryRoot);
-            }
-
-            var cloneTask = new CloneGitRepositoryTask(
-                logger,
-                normalizedRepos,
-                this.gitRunner ?? new ProcessGitRunner(logger),
-                this.fileSystem);
-
-            return cloneTask.ExecuteAsync();
         }
 
         protected override string GetAdditionalDisplayText() =>

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -46,8 +45,6 @@ namespace Cnct.Core.Configuration
         {
             return Array.Empty<ValidationIssue>();
         }
-
-        public abstract Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
 
         protected ValidationIssue CreateValidationError(string message)
         {

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -20,7 +20,7 @@ namespace Cnct.Core.Configuration
         public IReadOnlyCollection<string> MachineTags { get; set; } = Array.Empty<string>();
 
         [JsonIgnore]
-        public IActionRunner Runner { get; set; }
+        public IActionRunner Runner { get; set; } = new ActionRunner();
 
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -17,6 +18,9 @@ namespace Cnct.Core.Configuration
 
         [JsonIgnore]
         public IReadOnlyCollection<string> MachineTags { get; set; } = Array.Empty<string>();
+
+        [JsonIgnore]
+        public IActionRunner Runner { get; set; }
 
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }
@@ -68,7 +72,7 @@ namespace Cnct.Core.Configuration
                     var start = DateTimeOffset.Now;
                     this.Logger.LogStart(displayText);
 
-                    await action.ExecuteAsync(new IndentedLogger(this.Logger), this.ConfigRootDirectory);
+                    await this.Runner.ExecuteAsync(action, new IndentedLogger(this.Logger), this.ConfigRootDirectory);
 
                     var end = DateTimeOffset.Now;
                     var elapsed = end - start;

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
 
 namespace Cnct.Core.Configuration
@@ -46,16 +44,6 @@ namespace Cnct.Core.Configuration
             }
 
             return issues;
-        }
-
-        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-        {
-            var copyTask = new CopyTask(
-                logger,
-                this.fileSystem,
-                this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Files));
-
-            await copyTask.ExecuteAsync();
         }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Cnct.Core.Tasks.EnvironmentVariable;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -9,33 +7,11 @@ namespace Cnct.Core.Configuration
     [CnctActionType("environmentVariable")]
     public partial class EnvironmentVariableTaskSpecification : CnctActionSpecBase
     {
-        private readonly IEnvironmentVariableWriter writer;
-
-        public EnvironmentVariableTaskSpecification(IEnvironmentVariableWriter writer)
-        {
-            this.writer = writer;
-        }
-
-        public EnvironmentVariableTaskSpecification()
-            : this(new EnvironmentVariableWriter())
-        {
-        }
-
         [JsonRequired]
         public string Name { get; set; }
 
         [JsonRequired]
         public string Value { get; set; }
-
-        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-        {
-            var envVariableTask = new EnvironmentVariableTask(
-                logger,
-                this.writer,
-                this.Name,
-                this.Value);
-            await envVariableTask.ExecuteAsync();
-        }
 
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -17,7 +16,5 @@ namespace Cnct.Core.Configuration
         bool ShouldExecuteOnCurrentPlatform();
 
         IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot);
-
-        Task ExecuteAsync(ILogger logger, string configDirectoryRoot);
     }
 }

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Threading.Tasks;
-using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -56,14 +54,6 @@ namespace Cnct.Core.Configuration
             }
 
             return issues;
-        }
-
-        public override Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-        {
-            string source = this.pathResolver.Resolve(this.Source, configDirectoryRoot);
-            string target = this.Target.NormalizePath();
-            var linkExpandTask = new LinkExpandTask(logger, source, target, this.fileSystem);
-            return linkExpandTask.ExecuteAsync();
         }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Threading.Tasks;
-using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -46,16 +44,6 @@ namespace Cnct.Core.Configuration
             }
 
             return issues;
-        }
-
-        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-        {
-            var linkTask = new LinkTask(
-                logger,
-                this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links),
-                this.fileSystem);
-
-            await linkTask.ExecuteAsync();
         }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Cnct.Core.Tasks.Shell;
 using Cnct.Core.Validation;
 using Newtonsoft.Json;
 
@@ -9,18 +7,6 @@ namespace Cnct.Core.Configuration
     [CnctActionType("shell")]
     public partial class ShellTaskSpecification : CnctActionSpecBase
     {
-        private readonly IShellInvokerFactory shellInvokerFactory;
-
-        public ShellTaskSpecification()
-            : this(new ShellInvokerFactory())
-        {
-        }
-
-        public ShellTaskSpecification(IShellInvokerFactory shellInvokerFactory)
-        {
-            this.shellInvokerFactory = shellInvokerFactory;
-        }
-
         [JsonRequired]
         public ShellType Shell { get; set; }
 
@@ -28,14 +14,6 @@ namespace Cnct.Core.Configuration
         public string Command { get; set; }
 
         public bool Silent { get; set; }
-
-        public override async Task ExecuteAsync(ILogger logger, string configDirectoryRoot)
-        {
-            IShellInvoker shellInvoker = this.shellInvokerFactory.Create(this.Shell, logger);
-
-            var options = new ShellExecutionOptions(this.Command, this.Silent);
-            await shellInvoker.ExecuteAsync(options);
-        }
 
         public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {

--- a/Cnct/Cnct.Core/Tasks/ActionRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/ActionRunner.cs
@@ -5,12 +5,7 @@ namespace Cnct.Core.Tasks
 {
     public partial class ActionRunner : IActionRunner
     {
-        public Task ExecuteAsync(
-            ICnctActionSpec spec,
-            ILogger logger,
-            string configDirectoryRoot)
-        {
-            return DispatchAsync(spec, logger, configDirectoryRoot);
-        }
+        public Task ExecuteAsync(ICnctActionSpec spec, ILogger logger, string configDirectoryRoot)
+            => DispatchAsync(spec, logger, configDirectoryRoot);
     }
 }

--- a/Cnct/Cnct.Core/Tasks/ActionRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/ActionRunner.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+
+namespace Cnct.Core.Tasks
+{
+    public partial class ActionRunner : IActionRunner
+    {
+        public Task ExecuteAsync(
+            ICnctActionSpec spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            return DispatchAsync(spec, logger, configDirectoryRoot);
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
@@ -34,8 +34,7 @@ namespace Cnct.Core.Tasks
             var normalizedRepos = new Dictionary<string, string>();
             foreach (var kvp in spec.Repos)
             {
-                normalizedRepos[kvp.Key] = pathResolver.Resolve(
-                    kvp.Value, configDirectoryRoot);
+                normalizedRepos[kvp.Key] = pathResolver.Resolve(kvp.Value, configDirectoryRoot);
             }
 
             return new CloneGitRepositoryTask(

--- a/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
@@ -24,7 +24,7 @@ namespace Cnct.Core.Tasks
             this.fileSystem = fileSystem;
         }
 
-        public static CloneGitRepositoryTask FromTaskSpecification(
+        public static partial CloneGitRepositoryTask FromTaskSpecification(
             CloneGitRepositoryTaskSpecification spec,
             ILogger logger,
             string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
+using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks
 {
-    internal class CloneGitRepositoryTask : CnctTaskBase
+    internal partial class CloneGitRepositoryTask
     {
         private readonly IFileSystem fileSystem;
         private readonly IReadOnlyDictionary<string, string> repos;
@@ -21,6 +22,27 @@ namespace Cnct.Core.Tasks
             this.repos = repos;
             this.gitRunner = gitRunner;
             this.fileSystem = fileSystem;
+        }
+
+        public static CloneGitRepositoryTask FromTaskSpecification(
+            CloneGitRepositoryTaskSpecification spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            var fileSystem = new FileSystem();
+            var pathResolver = new PathResolver(fileSystem);
+            var normalizedRepos = new Dictionary<string, string>();
+            foreach (var kvp in spec.Repos)
+            {
+                normalizedRepos[kvp.Key] = pathResolver.Resolve(
+                    kvp.Value, configDirectoryRoot);
+            }
+
+            return new CloneGitRepositoryTask(
+                logger,
+                normalizedRepos,
+                new ProcessGitRunner(logger),
+                fileSystem);
         }
 
         public override async Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/CopyTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CopyTask.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
+using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks
 {
-    public class CopyTask : CnctTaskBase
+    public partial class CopyTask
     {
         private readonly IFileSystem fileSystem;
         private readonly IDictionary<string, IEnumerable<string>> fileMap;
@@ -17,6 +18,20 @@ namespace Cnct.Core.Tasks
         {
             this.fileSystem = fileSystem;
             this.fileMap = fileMap;
+        }
+
+        public static CopyTask FromTaskSpecification(
+            CopyTaskSpecification spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            var fileManagement = new FileManagement();
+            var fileSystem = new FileSystem();
+            return new CopyTask(
+                logger,
+                fileSystem,
+                fileManagement.GetFileConfigurations(
+                    configDirectoryRoot, spec.Files));
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/CopyTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CopyTask.cs
@@ -26,12 +26,11 @@ namespace Cnct.Core.Tasks
             string configDirectoryRoot)
         {
             var fileManagement = new FileManagement();
-            var fileSystem = new FileSystem();
+
             return new CopyTask(
                 logger,
-                fileSystem,
-                fileManagement.GetFileConfigurations(
-                    configDirectoryRoot, spec.Files));
+                new FileSystem(),
+                fileManagement.GetFileConfigurations(configDirectoryRoot, spec.Files));
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/CopyTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CopyTask.cs
@@ -20,7 +20,7 @@ namespace Cnct.Core.Tasks
             this.fileMap = fileMap;
         }
 
-        public static CopyTask FromTaskSpecification(
+        public static partial CopyTask FromTaskSpecification(
             CopyTaskSpecification spec,
             ILogger logger,
             string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
+++ b/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
@@ -20,7 +20,7 @@ namespace Cnct.Core.Tasks.EnvironmentVariable
             this.Value = value;
         }
 
-        public static EnvironmentVariableTask FromTaskSpecification(
+        public static partial EnvironmentVariableTask FromTaskSpecification(
             EnvironmentVariableTaskSpecification spec,
             ILogger logger,
             string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
+++ b/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
@@ -25,11 +25,7 @@ namespace Cnct.Core.Tasks.EnvironmentVariable
             ILogger logger,
             string configDirectoryRoot)
         {
-            return new EnvironmentVariableTask(
-                logger,
-                new EnvironmentVariableWriter(),
-                spec.Name,
-                spec.Value);
+            return new EnvironmentVariableTask(logger, new EnvironmentVariableWriter(), spec.Name, spec.Value);
         }
 
         public string Name { get; set; }

--- a/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
+++ b/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.EnvironmentVariable
 {
-    internal class EnvironmentVariableTask : CnctTaskBase
+    internal partial class EnvironmentVariableTask
     {
         private readonly IEnvironmentVariableWriter writer;
-
-        public string Name { get; set; }
-
-        public string Value { get; set; }
 
         public EnvironmentVariableTask(
             ILogger logger,
@@ -22,6 +19,22 @@ namespace Cnct.Core.Tasks.EnvironmentVariable
             this.Name = name;
             this.Value = value;
         }
+
+        public static EnvironmentVariableTask FromTaskSpecification(
+            EnvironmentVariableTaskSpecification spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            return new EnvironmentVariableTask(
+                logger,
+                new EnvironmentVariableWriter(),
+                spec.Name,
+                spec.Value);
+        }
+
+        public string Name { get; set; }
+
+        public string Value { get; set; }
 
         public override Task ExecuteAsync()
         {

--- a/Cnct/Cnct.Core/Tasks/IActionRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/IActionRunner.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+
+namespace Cnct.Core.Tasks
+{
+    public interface IActionRunner
+    {
+        Task ExecuteAsync(
+            ICnctActionSpec spec,
+            ILogger logger,
+            string configDirectoryRoot);
+    }
+}

--- a/Cnct/Cnct.Core/Tasks/IActionRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/IActionRunner.cs
@@ -5,9 +5,6 @@ namespace Cnct.Core.Tasks
 {
     public interface IActionRunner
     {
-        Task ExecuteAsync(
-            ICnctActionSpec spec,
-            ILogger logger,
-            string configDirectoryRoot);
+        Task ExecuteAsync(ICnctActionSpec spec, ILogger logger, string configDirectoryRoot);
     }
 }

--- a/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
@@ -31,11 +31,10 @@ namespace Cnct.Core.Tasks
         {
             var fileSystem = new FileSystem();
             var pathResolver = new PathResolver(fileSystem);
-            string source = pathResolver.Resolve(
-                spec.Source, configDirectoryRoot);
+            string source = pathResolver.Resolve(spec.Source, configDirectoryRoot);
             string target = spec.Target.NormalizePath();
-            return new LinkExpandTask(
-                logger, source, target, fileSystem);
+
+            return new LinkExpandTask(logger, source, target, fileSystem);
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
@@ -24,7 +24,7 @@ namespace Cnct.Core.Tasks
             this.fileSystem = fileSystem;
         }
 
-        public static LinkExpandTask FromTaskSpecification(
+        public static partial LinkExpandTask FromTaskSpecification(
             LinkExpandTaskSpecification spec,
             ILogger logger,
             string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
+using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks
 {
-    internal class LinkExpandTask : CnctTaskBase
+    internal partial class LinkExpandTask
     {
         private readonly IFileSystem fileSystem;
         private readonly string source;
@@ -21,6 +22,20 @@ namespace Cnct.Core.Tasks
             this.source = source;
             this.target = target;
             this.fileSystem = fileSystem;
+        }
+
+        public static LinkExpandTask FromTaskSpecification(
+            LinkExpandTaskSpecification spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            var fileSystem = new FileSystem();
+            var pathResolver = new PathResolver(fileSystem);
+            string source = pathResolver.Resolve(
+                spec.Source, configDirectoryRoot);
+            string target = spec.Target.NormalizePath();
+            return new LinkExpandTask(
+                logger, source, target, fileSystem);
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
@@ -40,12 +40,10 @@ namespace Cnct.Core.Tasks
             string configDirectoryRoot)
         {
             var fileManagement = new FileManagement();
-            var fileSystem = new FileSystem();
             return new LinkTask(
                 logger,
-                fileManagement.GetFileConfigurations(
-                    configDirectoryRoot, spec.Links),
-                fileSystem);
+                fileManagement.GetFileConfigurations(configDirectoryRoot, spec.Links),
+                new FileSystem());
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
@@ -34,7 +34,7 @@ namespace Cnct.Core.Tasks
             this.symlinkCreator = symlinkCreator;
         }
 
-        public static LinkTask FromTaskSpecification(
+        public static partial LinkTask FromTaskSpecification(
             LinkTaskSpecification spec,
             ILogger logger,
             string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
@@ -6,7 +6,7 @@ using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks
 {
-    internal class LinkTask : CnctTaskBase
+    internal partial class LinkTask
     {
         private readonly IFileSystem fileSystem;
         private readonly IDictionary<string, IEnumerable<string>> links;
@@ -32,6 +32,20 @@ namespace Cnct.Core.Tasks
             this.links = links;
             this.fileSystem = fileSystem;
             this.symlinkCreator = symlinkCreator;
+        }
+
+        public static LinkTask FromTaskSpecification(
+            LinkTaskSpecification spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            var fileManagement = new FileManagement();
+            var fileSystem = new FileSystem();
+            return new LinkTask(
+                logger,
+                fileManagement.GetFileConfigurations(
+                    configDirectoryRoot, spec.Links),
+                fileSystem);
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using Cnct.Core.Configuration;
-using static Cnct.Core.Configuration.ShellTaskSpecification;
 
 namespace Cnct.Core.Tasks.Shell
 {

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
@@ -25,11 +25,11 @@ namespace Cnct.Core.Tasks.Shell
             string configDirectoryRoot)
         {
             var factory = new ShellInvokerFactory();
-            IShellInvoker invoker = factory.Create(
-                spec.Shell, logger);
-            var options = new ShellExecutionOptions(
-                spec.Command, spec.Silent);
-            return new ShellTask(logger, invoker, options);
+
+            return new ShellTask(
+                logger,
+                factory.Create(spec.Shell, logger),
+                new ShellExecutionOptions(spec.Command, spec.Silent));
         }
 
         public override Task ExecuteAsync()

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
@@ -18,7 +18,7 @@ namespace Cnct.Core.Tasks.Shell
             this.options = options;
         }
 
-        public static ShellTask FromTaskSpecification(
+        public static partial ShellTask FromTaskSpecification(
             ShellTaskSpecification spec,
             ILogger logger,
             string configDirectoryRoot)

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using static Cnct.Core.Configuration.ShellTaskSpecification;
+
+namespace Cnct.Core.Tasks.Shell
+{
+    internal partial class ShellTask
+    {
+        private readonly IShellInvoker shellInvoker;
+        private readonly ShellExecutionOptions options;
+
+        public ShellTask(
+            ILogger logger,
+            IShellInvoker shellInvoker,
+            ShellExecutionOptions options)
+            : base(logger)
+        {
+            this.shellInvoker = shellInvoker;
+            this.options = options;
+        }
+
+        public static ShellTask FromTaskSpecification(
+            ShellTaskSpecification spec,
+            ILogger logger,
+            string configDirectoryRoot)
+        {
+            var factory = new ShellInvokerFactory();
+            IShellInvoker invoker = factory.Create(
+                spec.Shell, logger);
+            var options = new ShellExecutionOptions(
+                spec.Command, spec.Silent);
+            return new ShellTask(logger, invoker, options);
+        }
+
+        public override Task ExecuteAsync()
+        {
+            return this.shellInvoker.ExecuteAsync(this.options);
+        }
+    }
+}

--- a/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
+++ b/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
@@ -17,9 +17,11 @@ namespace Cnct.SourceGeneration
         public void Execute(GeneratorExecutionContext context)
         {
             const string CnctActionConverterClassName = "CnctActionConverter";
+            const string ActionRunnerClassName = "ActionRunner";
             const string AttributeName = "CnctActionType";
             var syntaxReceiver = context.SyntaxReceiver as ActionSpecSyntaxReceiver;
             var actionTypeToClassNameMap = new List<(string actionType, string className)>();
+            var taskClassInfoList = new List<(string specClassName, string taskClassName, string taskNamespace, string accessibility)>();
             foreach (ClassDeclarationSyntax cds in syntaxReceiver.ClassesToAugment)
             {
                 AttributeSyntax result = cds.AttributeLists
@@ -35,6 +37,22 @@ namespace Cnct.SourceGeneration
                     string className = cds.Identifier.ValueText;
                     this.AddActionSpecGeneratedSource(context, value, className);
                     actionTypeToClassNameMap.Add((value, className));
+
+                    string taskClassName = className.Replace("Specification", string.Empty);
+                    var taskSymbol = context.Compilation
+                        .GetSymbolsWithName(taskClassName, SymbolFilter.Type)
+                        .OfType<INamedTypeSymbol>()
+                        .FirstOrDefault();
+
+                    if (taskSymbol != null)
+                    {
+                        string taskNamespace = taskSymbol.ContainingNamespace.ToDisplayString();
+                        string accessibility = taskSymbol.DeclaredAccessibility == Accessibility.Public
+                            ? "public"
+                            : "internal";
+                        taskClassInfoList.Add((className, taskClassName, taskNamespace, accessibility));
+                        this.AddTaskGeneratedSource(context, taskClassName, taskNamespace, accessibility);
+                    }
                 }
             }
 
@@ -65,6 +83,8 @@ namespace {NamespaceCnctCoreConfiguration}
             context.AddSource(
                 $"{CnctActionConverterClassName}.g.cs",
                 SourceText.From(actionConverterSourceBuilder.ToString(), Encoding.UTF8));
+
+            this.AddActionRunnerGeneratedSource(context, ActionRunnerClassName, taskClassInfoList);
         }
 
         public void Initialize(GeneratorInitializationContext context)
@@ -88,6 +108,64 @@ namespace {NamespaceCnctCoreConfiguration}
 ";
 
             context.AddSource($"{className}.g.cs", SourceText.From(source, Encoding.UTF8));
+        }
+
+        private void AddTaskGeneratedSource(
+            GeneratorExecutionContext context,
+            string taskClassName,
+            string taskNamespace,
+            string accessibility)
+        {
+            string source = @$"
+namespace {taskNamespace}
+{{
+    {accessibility} partial class {taskClassName} : Cnct.Core.Tasks.CnctTaskBase
+    {{
+    }}
+}}
+";
+
+            context.AddSource($"{taskClassName}.g.cs", SourceText.From(source, Encoding.UTF8));
+        }
+
+        private void AddActionRunnerGeneratedSource(
+            GeneratorExecutionContext context,
+            string actionRunnerClassName,
+            List<(string specClassName, string taskClassName, string taskNamespace, string accessibility)> taskClassInfoList)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("using System;");
+            sb.AppendLine("using System.Threading.Tasks;");
+            sb.AppendLine("using Cnct.Core.Configuration;");
+            sb.AppendLine();
+            sb.AppendLine("namespace Cnct.Core.Tasks");
+            sb.AppendLine("{");
+            sb.AppendLine($"    public partial class {actionRunnerClassName}");
+            sb.AppendLine("    {");
+            sb.AppendLine("        private static async Task DispatchAsync(");
+            sb.AppendLine("            ICnctActionSpec spec,");
+            sb.AppendLine("            ILogger logger,");
+            sb.AppendLine("            string configDirectoryRoot)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            ICnctTask task = spec switch");
+            sb.AppendLine("            {");
+
+            foreach (var (specClassName, taskClassName, taskNamespace, _) in taskClassInfoList)
+            {
+                string fullTaskName = $"{taskNamespace}.{taskClassName}";
+                sb.AppendLine($"                {specClassName} s => {fullTaskName}.FromTaskSpecification(s, logger, configDirectoryRoot),");
+            }
+
+            sb.AppendLine(@"                _ => throw new NotSupportedException($""Action type '{spec.ActionType}' is not supported.""),");
+            sb.AppendLine("            };");
+            sb.AppendLine("            await task.ExecuteAsync();");
+            sb.AppendLine("        }");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+
+            context.AddSource(
+                $"{actionRunnerClassName}.g.cs",
+                SourceText.From(sb.ToString(), Encoding.UTF8));
         }
 
         private class ActionSpecSyntaxReceiver : ISyntaxReceiver

--- a/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
+++ b/Cnct/Cnct.SourceGeneration/CnctTaskSpecificationGenerator.cs
@@ -51,7 +51,7 @@ namespace Cnct.SourceGeneration
                             ? "public"
                             : "internal";
                         taskClassInfoList.Add((className, taskClassName, taskNamespace, accessibility));
-                        this.AddTaskGeneratedSource(context, taskClassName, taskNamespace, accessibility);
+                        this.AddTaskGeneratedSource(context, className, taskClassName, taskNamespace, accessibility);
                     }
                 }
             }
@@ -112,6 +112,7 @@ namespace {NamespaceCnctCoreConfiguration}
 
         private void AddTaskGeneratedSource(
             GeneratorExecutionContext context,
+            string specClassName,
             string taskClassName,
             string taskNamespace,
             string accessibility)
@@ -121,6 +122,10 @@ namespace {taskNamespace}
 {{
     {accessibility} partial class {taskClassName} : Cnct.Core.Tasks.CnctTaskBase
     {{
+        public static partial {taskClassName} FromTaskSpecification(
+            {NamespaceCnctCoreConfiguration}.{specClassName} spec,
+            ILogger logger,
+            string configDirectoryRoot);
     }}
 }}
 ";


### PR DESCRIPTION
## Phase 8: Per-task factory methods with source-generated dispatch

### Summary

Replaces the monolithic `ActionRunner` (which held all execution
dependencies and used a hardcoded switch) with a source-generated
dispatch layer. Each task class now has a `FromTaskSpecification`
factory method, and the source generator auto-generates the
`ActionRunner` dispatch from existing `[CnctActionType]`
attributes on spec classes.

### Design

Each existing task class (LinkTask, CopyTask, etc.) is made
`partial` and gains a static `FromTaskSpecification` factory
method. This method constructs the task from its specification,
creating production-default dependencies internally.

The source generator (`CnctTaskSpecificationGenerator`) is
extended to produce:
1. Per-task partial declarations with `: CnctTaskBase`
   inheritance (hand-written parts omit the base class)
2. `ActionRunner.g.cs` with a dispatch switch that calls each
   task's factory method, derived by convention: strip
   "Specification" from spec class name to get task class name

`ActionRunner` is now a zero-dependency partial class that
delegates to the generated `DispatchAsync` method.

### Changes

**New files:**
- `IActionRunner.cs` - interface: `ExecuteAsync(ICnctActionSpec, ILogger, string)`
- `ActionRunner.cs` - thin partial calling generated dispatch
- `ShellTask.cs` - new task class wrapping `ShellInvokerFactory`
  (the only action type that had no corresponding task class)

**Task classes modified (made partial, added FromTaskSpecification):**
- `LinkTask`, `CopyTask`, `LinkExpandTask`,
  `CloneGitRepositoryTask`, `EnvironmentVariableTask`

**Source generator extended:**
- Generates `XxxTask.g.cs` partials with `: CnctTaskBase`
- Generates `ActionRunner.g.cs` dispatch switch

**Interface changes:**
- Removed `ExecuteAsync` from `ICnctActionSpec` and
  `CnctActionSpecBase`
- All six spec classes no longer have `ExecuteAsync` overrides
- Specs that need deps for **validation** retain their deps

**Wiring:**
- `CnctConfig` gains an `IActionRunner Runner` property
- `CnctCommandLine` constructs `ActionRunner` and sets it

**Tests:**
- `ActionRunnerTests` - single test for unsupported spec type
  (execution behavior covered by existing per-task tests)
- `CnctConfigTagFilteringTests` - verifies via mock
  `IActionRunner`
- 98 tests passing, zero warnings