### PR TITLE
Modernize C# syntax for LangVersion 12

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,6 +141,10 @@ The following rules are **suppressed** (severity = none):
 - CA1031 (catching general exceptions allowed)
 - CA1819 (array properties allowed)
 
+## Branching
+
+Feature PRs must always target the `develop` branch, not `main`.
+
 ## Markdown
 
 All markdown files must comply with `.markdownlint.json`:

--- a/Cnct/Cnct.Core.Tests/ActionRunnerTests.cs
+++ b/Cnct/Cnct.Core.Tests/ActionRunnerTests.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
-using Moq;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctConfigTagFilteringTests.cs
@@ -14,7 +14,7 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasNoTags()
         {
             var action = new TestActionSpec();
-            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig([], action);
 
             await config.ExecuteAsync();
 
@@ -27,7 +27,7 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasTags()
         {
             var action = new TestActionSpec();
-            var (config, runner) = MakeConfig(new[] { "personal" }, action);
+            var (config, runner) = MakeConfig(["personal"], action);
 
             await config.ExecuteAsync();
 
@@ -39,8 +39,8 @@ namespace Cnct.Core.Tests
         [Fact]
         public async Task ExecuteAsync_RunsTaggedAction_WhenMachineTagMatches()
         {
-            var action = new TestActionSpec { Tags = new[] { "personal" } };
-            var (config, runner) = MakeConfig(new[] { "personal" }, action);
+            var action = new TestActionSpec { Tags = ["personal"] };
+            var (config, runner) = MakeConfig(["personal"], action);
 
             await config.ExecuteAsync();
 
@@ -52,8 +52,8 @@ namespace Cnct.Core.Tests
         [Fact]
         public async Task ExecuteAsync_SkipsTaggedAction_WhenNoMachineTags()
         {
-            var action = new TestActionSpec { Tags = new[] { "personal" } };
-            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
+            var action = new TestActionSpec { Tags = ["personal"] };
+            var (config, runner) = MakeConfig([], action);
 
             await config.ExecuteAsync();
 
@@ -68,8 +68,8 @@ namespace Cnct.Core.Tests
         [Fact]
         public async Task ExecuteAsync_SkipsTaggedAction_WhenMachineTagsDoNotMatch()
         {
-            var action = new TestActionSpec { Tags = new[] { "personal" } };
-            var (config, runner) = MakeConfig(new[] { "work" }, action);
+            var action = new TestActionSpec { Tags = ["personal"] };
+            var (config, runner) = MakeConfig(["work"], action);
 
             await config.ExecuteAsync();
 
@@ -84,8 +84,8 @@ namespace Cnct.Core.Tests
         [Fact]
         public async Task ExecuteAsync_RunsTaggedAction_CaseInsensitiveMatch()
         {
-            var action = new TestActionSpec { Tags = new[] { "Personal" } };
-            var (config, runner) = MakeConfig(new[] { "personal" }, action);
+            var action = new TestActionSpec { Tags = ["Personal"] };
+            var (config, runner) = MakeConfig(["personal"], action);
 
             await config.ExecuteAsync();
 
@@ -97,8 +97,8 @@ namespace Cnct.Core.Tests
         [Fact]
         public async Task ExecuteAsync_RunsTaggedAction_WhenAnyTagMatches()
         {
-            var action = new TestActionSpec { Tags = new[] { "personal", "home" } };
-            var (config, runner) = MakeConfig(new[] { "work", "home" }, action);
+            var action = new TestActionSpec { Tags = ["personal", "home"] };
+            var (config, runner) = MakeConfig(["work", "home"], action);
 
             await config.ExecuteAsync();
 
@@ -111,9 +111,9 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsUntaggedAndSkipsTagged_Mixed()
         {
             var untaggedAction = new TestActionSpec();
-            var taggedAction = new TestActionSpec { Tags = new[] { "personal" } };
+            var taggedAction = new TestActionSpec { Tags = ["personal"] };
             var (config, runner) = MakeConfig(
-                Array.Empty<string>(), untaggedAction, taggedAction);
+                [], untaggedAction, taggedAction);
 
             await config.ExecuteAsync();
 
@@ -138,8 +138,8 @@ namespace Cnct.Core.Tests
                 Logger = logger.Object,
                 Runner = runner.Object,
                 ConfigRootDirectory = "/",
-                MachineTags = Array.Empty<string>(),
-                Actions = new ICnctActionSpec[] { action },
+                MachineTags = [],
+                Actions = [action],
             };
 
             await config.ExecuteAsync();
@@ -161,8 +161,8 @@ namespace Cnct.Core.Tests
                 Logger = logger.Object,
                 Runner = runner.Object,
                 ConfigRootDirectory = "/",
-                MachineTags = Array.Empty<string>(),
-                Actions = new ICnctActionSpec[] { action },
+                MachineTags = [],
+                Actions = [action],
             };
 
             await config.ExecuteAsync();
@@ -184,8 +184,8 @@ namespace Cnct.Core.Tests
                 Logger = logger.Object,
                 Runner = runner.Object,
                 ConfigRootDirectory = "/",
-                MachineTags = Array.Empty<string>(),
-                Actions = new ICnctActionSpec[] { action },
+                MachineTags = [],
+                Actions = [action],
             };
 
             await config.ExecuteAsync();
@@ -203,15 +203,15 @@ namespace Cnct.Core.Tests
                 : PlatformType.Windows;
             var action = new TestActionSpec
             {
-                PlatformType = new[] { nonCurrentPlatform },
+                PlatformType = [nonCurrentPlatform],
             };
             var config = new CnctConfig
             {
                 Logger = logger.Object,
                 Runner = runner.Object,
                 ConfigRootDirectory = "/",
-                MachineTags = Array.Empty<string>(),
-                Actions = new ICnctActionSpec[] { action },
+                MachineTags = [],
+                Actions = [action],
             };
 
             await config.ExecuteAsync();
@@ -240,9 +240,9 @@ namespace Cnct.Core.Tests
         {
             var action = new TestActionSpec
             {
-                PlatformType = new[] { Platform.CurrentPlatform },
+                PlatformType = [Platform.CurrentPlatform],
             };
-            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig([], action);
 
             await config.ExecuteAsync();
 
@@ -255,7 +255,7 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsAction_WhenOsNotSpecified()
         {
             var action = new TestActionSpec();
-            var (config, runner) = MakeConfig(Array.Empty<string>(), action);
+            var (config, runner) = MakeConfig([], action);
 
             await config.ExecuteAsync();
 

--- a/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Generic;
-using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/CopyTaskTests.cs
+++ b/Cnct/Cnct.Core.Tests/CopyTaskTests.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Threading.Tasks;
 using Cnct.Core.Tasks;
-using Moq;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {
@@ -13,7 +9,7 @@ namespace Cnct.Core.Tests
         public async Task CanCopyExistingFiles()
         {
             string sourceFile = "sourceFile";
-            var destinations = new[] { "d1", "d2" };
+            string[] destinations = ["d1", "d2"];
             var map = new Dictionary<string, IEnumerable<string>>
             {
                 [sourceFile] = destinations,
@@ -53,7 +49,7 @@ namespace Cnct.Core.Tests
         public async Task ThrowsForNonexistentSourceFile()
         {
             string sourceFile = "sourceFile";
-            var destinations = new[] { "d1", "d2" };
+            string[] destinations = ["d1", "d2"];
             var map = new Dictionary<string, IEnumerable<string>>
             {
                 [sourceFile] = destinations,
@@ -84,7 +80,7 @@ namespace Cnct.Core.Tests
             string sourceFile = "sourceFile";
             string existingDestinationFile = "ed1";
             string nonexistentDestinationFile = "ned1";
-            var destinations = new[] { existingDestinationFile, nonexistentDestinationFile };
+            string[] destinations = [existingDestinationFile, nonexistentDestinationFile];
             var map = new Dictionary<string, IEnumerable<string>>
             {
                 [sourceFile] = destinations,

--- a/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/FileManagementTests.cs
+++ b/Cnct/Cnct.Core.Tests/FileManagementTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Cnct.Core.Configuration;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {
@@ -91,7 +86,7 @@ namespace Cnct.Core.Tests
         {
             TestPlatformFiles(PlatformType.Windows, new FileSpecification
             {
-                Windows = Array.Empty<string>(),
+                Windows = [],
             });
         }
 
@@ -103,7 +98,7 @@ namespace Cnct.Core.Tests
         {
             TestPlatformFiles(PlatformType.Linux, new FileSpecification
             {
-                Linux = Array.Empty<string>(),
+                Linux = [],
             });
         }
 
@@ -115,7 +110,7 @@ namespace Cnct.Core.Tests
         {
             TestPlatformFiles(PlatformType.OSX, new FileSpecification
             {
-                Osx = Array.Empty<string>(),
+                Osx = [],
             });
         }
 
@@ -130,7 +125,7 @@ namespace Cnct.Core.Tests
                 Platform.CurrentPlatformIsUnix,
                 new FileSpecification
                 {
-                    Unix = Array.Empty<string>(),
+                    Unix = [],
                 });
         }
 

--- a/Cnct/Cnct.Core.Tests/GlobalUsings.cs
+++ b/Cnct/Cnct.Core.Tests/GlobalUsings.cs
@@ -1,0 +1,9 @@
+global using System;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.IO.Abstractions.TestingHelpers;
+global using System.Linq;
+global using System.Threading.Tasks;
+global using Moq;
+global using Newtonsoft.Json;
+global using Xunit;

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Generic;
-using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/MachineSettingsLoaderTests.cs
+++ b/Cnct/Cnct.Core.Tests/MachineSettingsLoaderTests.cs
@@ -1,8 +1,4 @@
-using System.IO.Abstractions.TestingHelpers;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/PackageVersionsTests.cs
+++ b/Cnct/Cnct.Core.Tests/PackageVersionsTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.IO;
-using System.Linq;
 using System.Xml.Linq;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/PathExtensionsTests.cs
+++ b/Cnct/Cnct.Core.Tests/PathExtensionsTests.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
 using Cnct.Core.Configuration;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/PathResolverTests.cs
+++ b/Cnct/Cnct.Core.Tests/PathResolverTests.cs
@@ -1,7 +1,4 @@
-using System.IO;
-using System.IO.Abstractions.TestingHelpers;
 using Cnct.Core.Configuration;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/PlatformTests.cs
+++ b/Cnct/Cnct.Core.Tests/PlatformTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
 using System.Runtime.InteropServices;
 using Cnct.Core.Configuration;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/PowerShellInvokerTests.cs
+++ b/Cnct/Cnct.Core.Tests/PowerShellInvokerTests.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
-using Moq;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/ShInvokerTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShInvokerTests.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using Cnct.Core.Tasks.Shell;
-using Moq;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/ShellInvokerFactoryTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellInvokerFactoryTests.cs
@@ -1,12 +1,10 @@
-using System;
 using Cnct.Core.Tasks.Shell;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {
     public class ShellInvokerFactoryTests
     {
-        private readonly ShellInvokerFactory factory = new ShellInvokerFactory();
+        private readonly ShellInvokerFactory factory = new();
 
         [Fact]
         public void Create_PowerShell_ReturnsPowerShellInvoker()

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 using Cnct.Core.Configuration;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {

--- a/Cnct/Cnct.Core.Tests/StringCollectionConverterTests.cs
+++ b/Cnct/Cnct.Core.Tests/StringCollectionConverterTests.cs
@@ -1,8 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
 using Cnct.Core.Configuration;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {
@@ -13,7 +9,7 @@ namespace Cnct.Core.Tests
         {
             var json = JsonConvert.SerializeObject(new { tags = "personal" });
             var result = JsonConvert.DeserializeObject<TagsWrapper>(json);
-            Assert.Equal(new[] { "personal" }, result.Tags);
+            Assert.Equal(["personal"], result.Tags);
         }
 
         [Fact]
@@ -54,7 +50,7 @@ namespace Cnct.Core.Tests
         {
             [JsonProperty("tags")]
             [JsonConverter(typeof(StringCollectionConverter))]
-            public IReadOnlyCollection<string> Tags { get; set; } = System.Array.Empty<string>();
+            public IReadOnlyCollection<string> Tags { get; set; } = [];
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/SymlinkSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/SymlinkSpecificationTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
 using Cnct.Core.Configuration;
-using Newtonsoft.Json;
-using Xunit;
 
 namespace Cnct.Core.Tests
 {
@@ -17,9 +14,9 @@ namespace Cnct.Core.Tests
 }";
 
             var s = JsonConvert.DeserializeObject<FileSpecification>(json);
-            Assert.Equal(Array.Empty<string>(), s.Windows);
-            Assert.Equal(Array.Empty<string>(), s.Linux);
-            Assert.Equal(Array.Empty<string>(), s.Osx);
+            Assert.Equal((string[])[], s.Windows);
+            Assert.Equal((string[])[], s.Linux);
+            Assert.Equal((string[])[], s.Osx);
         }
 
         [Fact]
@@ -30,7 +27,7 @@ namespace Cnct.Core.Tests
 }";
 
             var s = JsonConvert.DeserializeObject<FileSpecification>(json);
-            Assert.Equal(Array.Empty<string>(), s.Windows);
+            Assert.Equal((string[])[], s.Windows);
             Assert.Null(s.Linux);
             Assert.Null(s.Osx);
         }
@@ -40,10 +37,10 @@ namespace Cnct.Core.Tests
         {
             string expectedLink = "some/path";
             string json = @"{
-  ""windows"": """ + expectedLink + "\"}";
+      ""windows"": """ + expectedLink + "\"}";
 
             var s = JsonConvert.DeserializeObject<FileSpecification>(json);
-            Assert.Equal(new[] { expectedLink }, s.Windows);
+            Assert.Equal([expectedLink], s.Windows);
             Assert.Null(s.Linux);
             Assert.Null(s.Osx);
         }

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -1,9 +1,5 @@
-﻿using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
@@ -73,7 +69,7 @@ namespace Cnct.Core
         private static Option CreateOption<T>(char shortName, string longName, string description)
         {
             return new Option(
-                new[] { $"-{shortName}", $"--{longName}" },
+                [$"-{shortName}", $"--{longName}"],
                 description)
             {
                 Argument = new Argument<T>(),

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {

--- a/Cnct/Cnct.Core/Configuration/CnctActionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionConverter.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Cnct.Core.Configuration
 {
     public partial class CnctActionConverter : JsonConverter<ICnctActionSpec>

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -32,7 +32,7 @@ namespace Cnct.Core.Configuration
 
         public bool ShouldExecuteOnCurrentPlatform()
         {
-            return this.PlatformType is null
+            return this.PlatformType == null
                 || this.PlatformType.Count == 0
                 || this.PlatformType.Contains(Platform.CurrentPlatform);
         }

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {
@@ -13,7 +9,7 @@ namespace Cnct.Core.Configuration
 
         [JsonProperty("tags")]
         [JsonConverter(typeof(StringCollectionConverter))]
-        public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> Tags { get; set; } = [];
 
         [JsonProperty("os")]
         [JsonConverter(typeof(EnumCollectionConverter<PlatformType>))]
@@ -36,14 +32,14 @@ namespace Cnct.Core.Configuration
 
         public bool ShouldExecuteOnCurrentPlatform()
         {
-            return this.PlatformType == null
+            return this.PlatformType is null
                 || this.PlatformType.Count == 0
                 || this.PlatformType.Contains(Platform.CurrentPlatform);
         }
 
         public virtual IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
         {
-            return Array.Empty<ValidationIssue>();
+            return [];
         }
 
         protected ValidationIssue CreateValidationError(string message)

--- a/Cnct/Cnct.Core/Configuration/CnctActionTypeAttribute.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionTypeAttribute.cs
@@ -1,5 +1,3 @@
-﻿using System;
-
 namespace Cnct.Core.Configuration
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Cnct.Core.Tasks;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {
@@ -17,7 +12,7 @@ namespace Cnct.Core.Configuration
         public string ConfigRootDirectory { get; set; }
 
         [JsonIgnore]
-        public IReadOnlyCollection<string> MachineTags { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> MachineTags { get; set; } = [];
 
         [JsonIgnore]
         public IActionRunner Runner { get; set; } = new ActionRunner();

--- a/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.IO;
-using System.IO.Abstractions;
-using Newtonsoft.Json;
-
 namespace Cnct.Core.Configuration
 {
     public class CnctConfigurationParser

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Abstractions;
-using System.Text.Json.Serialization;
 using Cnct.Core.Validation;
 
 namespace Cnct.Core.Configuration

--- a/Cnct/Cnct.Core/Configuration/EnumCollectionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/EnumCollectionConverter.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Cnct.Core.Configuration
 {
     public class EnumCollectionConverter<T> : JsonConverter<IReadOnlyCollection<T>>
@@ -15,7 +9,7 @@ namespace Cnct.Core.Configuration
             return token.Type switch
             {
                 JTokenType.Array => Convert(((JArray)token).Select(e => e.Value<string>())),
-                JTokenType.String => Convert(new[] { token.Value<string>() }),
+                JTokenType.String => Convert([token.Value<string>()]),
                 JTokenType.Null => new HashSet<T>(),
                 _ => throw new JsonSerializationException(),
             };

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {

--- a/Cnct/Cnct.Core/Configuration/FileManagement.cs
+++ b/Cnct/Cnct.Core/Configuration/FileManagement.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 namespace Cnct.Core.Configuration
 {
     public class FileManagement : IFileManagement
@@ -31,11 +26,11 @@ namespace Cnct.Core.Configuration
                 switch (destination)
                 {
                     case null:
-                        fileCopyConfigs.Add(sourceFile, new[] { GetDotFileLinkPath(sourceFile) });
+                        fileCopyConfigs.Add(sourceFile, [GetDotFileLinkPath(sourceFile)]);
                         break;
 
                     case string s:
-                        fileCopyConfigs.Add(sourceFile, new[] { s.NormalizePath() });
+                        fileCopyConfigs.Add(sourceFile, [s.NormalizePath()]);
                         break;
 
                     case FileSpecification spec:
@@ -74,7 +69,7 @@ namespace Cnct.Core.Configuration
             }
             else if (platformDestinations.Length == 0)
             {
-                destinations = new[] { GetDotFileLinkPath(sourceFile) };
+                destinations = [GetDotFileLinkPath(sourceFile)];
                 return true;
             }
             else

--- a/Cnct/Cnct.Core/Configuration/FileSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/FileSpecification.cs
@@ -1,5 +1,3 @@
-﻿using Newtonsoft.Json;
-
 namespace Cnct.Core.Configuration
 {
     public class FileSpecification

--- a/Cnct/Cnct.Core/Configuration/FileSpecificationCollectionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/FileSpecificationCollectionConverter.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Cnct.Core.Configuration
 {
     public class FileSpecificationCollectionConverter : JsonConverter<IDictionary<string, object>>

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {

--- a/Cnct/Cnct.Core/Configuration/IFileManagement.cs
+++ b/Cnct/Cnct.Core/Configuration/IFileManagement.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-
 namespace Cnct.Core.Configuration
 {
     public interface IFileManagement

--- a/Cnct/Cnct.Core/Configuration/LinkCollectionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkCollectionConverter.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Cnct.Core.Configuration
 {
     public class LinkCollectionConverter : JsonConverter<string[]>
@@ -11,24 +6,13 @@ namespace Cnct.Core.Configuration
         {
             var token = JToken.Load(reader);
 
-            string[] links;
-            switch (token.Type)
+            return token.Type switch
             {
-                case JTokenType.Array:
-                    var array = (JArray)token;
-                    links = array.Select(e => e.Value<string>()).ToArray();
-                    break;
-                case JTokenType.String:
-                    links = new[] { token.Value<string>() };
-                    break;
-                case JTokenType.Null:
-                    links = Array.Empty<string>();
-                    break;
-                default:
-                    throw new InvalidOperationException();
-            }
-
-            return links;
+                JTokenType.Array => ((JArray)token).Select(e => e.Value<string>()).ToArray(),
+                JTokenType.String => [token.Value<string>()],
+                JTokenType.Null => [],
+                _ => throw new InvalidOperationException(),
+            };
         }
 
         public override void WriteJson(JsonWriter writer, string[] value, JsonSerializer serializer)

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO.Abstractions;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Abstractions;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {

--- a/Cnct/Cnct.Core/Configuration/MachineSettings.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettings.cs
@@ -1,15 +1,11 @@
-using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
-
 namespace Cnct.Core.Configuration
 {
     public class MachineSettings
     {
-        public static readonly MachineSettings Empty = new MachineSettings();
+        public static readonly MachineSettings Empty = new();
 
         [JsonProperty("tags")]
         [JsonConverter(typeof(StringCollectionConverter))]
-        public IReadOnlyCollection<string> Tags { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> Tags { get; set; } = [];
     }
 }

--- a/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
@@ -1,9 +1,3 @@
-using System;
-using System.IO;
-using System.IO.Abstractions;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 namespace Cnct.Core.Configuration
 {
     public class MachineSettingsLoader
@@ -37,18 +31,15 @@ namespace Cnct.Core.Configuration
             return JsonConvert.DeserializeObject<MachineSettings>(json) ?? MachineSettings.Empty;
         }
 
-        private static string GetSettingsDirectory()
+        private static string GetSettingsDirectory() => Platform.CurrentPlatform switch
         {
-            switch (Platform.CurrentPlatform)
-            {
-                case PlatformType.Windows:
-                    return Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                case PlatformType.Linux:
-                case PlatformType.OSX:
-                    return Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ?? Path.Combine(Platform.Home, ".config");
-                default:
-                    throw new NotImplementedException($"Platform '{Platform.CurrentPlatform}' is not supported.");
-            }
-        }
+            PlatformType.Windows =>
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            PlatformType.Linux or PlatformType.OSX =>
+                Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+                ?? Path.Combine(Platform.Home, ".config"),
+            _ => throw new NotImplementedException(
+                $"Platform '{Platform.CurrentPlatform}' is not supported."),
+        };
     }
 }

--- a/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
+++ b/Cnct/Cnct.Core/Configuration/MachineSettingsLoader.cs
@@ -33,13 +33,11 @@ namespace Cnct.Core.Configuration
 
         private static string GetSettingsDirectory() => Platform.CurrentPlatform switch
         {
-            PlatformType.Windows =>
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            PlatformType.Windows => Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             PlatformType.Linux or PlatformType.OSX =>
                 Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
                 ?? Path.Combine(Platform.Home, ".config"),
-            _ => throw new NotImplementedException(
-                $"Platform '{Platform.CurrentPlatform}' is not supported."),
+            _ => throw new NotImplementedException($"Platform '{Platform.CurrentPlatform}' is not supported."),
         };
     }
 }

--- a/Cnct/Cnct.Core/Configuration/PathResolver.cs
+++ b/Cnct/Cnct.Core/Configuration/PathResolver.cs
@@ -1,5 +1,3 @@
-using System.IO.Abstractions;
-
 namespace Cnct.Core.Configuration
 {
     public class PathResolver : IPathResolver

--- a/Cnct/Cnct.Core/Configuration/Platform.cs
+++ b/Cnct/Cnct.Core/Configuration/Platform.cs
@@ -1,44 +1,25 @@
-﻿using System;
-using System.Runtime.InteropServices;
-
 namespace Cnct.Core.Configuration
 {
     public static class Platform
     {
-        private static readonly Lazy<PlatformType> CurrentPlatformLazy = new Lazy<PlatformType>(GetCurrentPlatformType);
+        private static readonly Lazy<PlatformType> CurrentPlatformLazy = new(GetCurrentPlatformType);
 
-        public static string Home
+        public static string Home => CurrentPlatform switch
         {
-            get
-            {
-                switch (CurrentPlatform)
-                {
-                    case PlatformType.Windows:
-                        return Environment.GetEnvironmentVariable("USERPROFILE");
-                    case PlatformType.Linux:
-                    case PlatformType.OSX:
-                        return Environment.GetEnvironmentVariable("HOME");
-                    default:
-                        return null;
-                }
-            }
-        }
+            PlatformType.Windows => Environment.GetEnvironmentVariable("USERPROFILE"),
+            PlatformType.Linux or PlatformType.OSX => Environment.GetEnvironmentVariable("HOME"),
+            _ => null,
+        };
 
         public static PlatformType CurrentPlatform => CurrentPlatformLazy.Value;
 
         public static bool CurrentPlatformIsUnix { get; } = IsUnix();
 
-        private static bool IsUnix()
+        private static bool IsUnix() => CurrentPlatform switch
         {
-            switch (CurrentPlatform)
-            {
-                case PlatformType.Linux:
-                case PlatformType.OSX:
-                    return true;
-                default:
-                    return false;
-            }
-        }
+            PlatformType.Linux or PlatformType.OSX => true,
+            _ => false,
+        };
 
         private static PlatformType GetCurrentPlatformType()
         {

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
 using Cnct.Core.Validation;
-using Newtonsoft.Json;
 
 namespace Cnct.Core.Configuration
 {

--- a/Cnct/Cnct.Core/Configuration/StringCollectionConverter.cs
+++ b/Cnct/Cnct.Core/Configuration/StringCollectionConverter.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Cnct.Core.Configuration
 {
     public class StringCollectionConverter : JsonConverter<IReadOnlyCollection<string>>

--- a/Cnct/Cnct.Core/ConsoleLogger.cs
+++ b/Cnct/Cnct.Core/ConsoleLogger.cs
@@ -1,5 +1,3 @@
-﻿using System;
-
 namespace Cnct.Core
 {
     public class ConsoleLogger : ILogger

--- a/Cnct/Cnct.Core/GlobalUsings.cs
+++ b/Cnct/Cnct.Core/GlobalUsings.cs
@@ -1,0 +1,10 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.IO;
+global using System.IO.Abstractions;
+global using System.Linq;
+global using System.Runtime.InteropServices;
+global using System.Threading.Tasks;
+global using Newtonsoft.Json;
+global using Newtonsoft.Json.Linq;

--- a/Cnct/Cnct.Core/ILogger.cs
+++ b/Cnct/Cnct.Core/ILogger.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Cnct.Core

--- a/Cnct/Cnct.Core/IndentedLogger.cs
+++ b/Cnct/Cnct.Core/IndentedLogger.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cnct.Core
 {
     internal class IndentedLogger : ILogger

--- a/Cnct/Cnct.Core/LoggerOptions.cs
+++ b/Cnct/Cnct.Core/LoggerOptions.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Cnct.Core

--- a/Cnct/Cnct.Core/NativeMethods.cs
+++ b/Cnct/Cnct.Core/NativeMethods.cs
@@ -1,6 +1,4 @@
-﻿using System;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using Cnct.Core.Tasks;
 
 namespace Cnct.Core

--- a/Cnct/Cnct.Core/PathExtensions.cs
+++ b/Cnct/Cnct.Core/PathExtensions.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.IO;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core

--- a/Cnct/Cnct.Core/Tasks/ActionRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/ActionRunner.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks

--- a/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CloneGitRepositoryTask.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.IO.Abstractions;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks

--- a/Cnct/Cnct.Core/Tasks/CnctTaskBase.cs
+++ b/Cnct/Cnct.Core/Tasks/CnctTaskBase.cs
@@ -1,5 +1,3 @@
-﻿using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks
 {
     public abstract class CnctTaskBase : ICnctTask

--- a/Cnct/Cnct.Core/Tasks/CopyTask.cs
+++ b/Cnct/Cnct.Core/Tasks/CopyTask.cs
@@ -1,6 +1,3 @@
-﻿using System.Collections.Generic;
-using System.IO.Abstractions;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks

--- a/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
+++ b/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableTask.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.EnvironmentVariable

--- a/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableWriter.cs
+++ b/Cnct/Cnct.Core/Tasks/EnvironmentVariable/EnvironmentVariableWriter.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cnct.Core.Tasks.EnvironmentVariable
 {
     public class EnvironmentVariableWriter : IEnvironmentVariableWriter

--- a/Cnct/Cnct.Core/Tasks/IActionRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/IActionRunner.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks

--- a/Cnct/Cnct.Core/Tasks/ICnctTask.cs
+++ b/Cnct/Cnct.Core/Tasks/ICnctTask.cs
@@ -1,5 +1,3 @@
-﻿using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks
 {
     internal interface ICnctTask

--- a/Cnct/Cnct.Core/Tasks/IGitRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/IGitRunner.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks
 {
     public interface IGitRunner

--- a/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkExpandTask.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.IO.Abstractions;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks
@@ -50,7 +47,7 @@ namespace Cnct.Core.Tasks
             {
                 string name = this.fileSystem.Path.GetFileName(subdirectory);
                 string linkPath = this.fileSystem.Path.Combine(this.target, name);
-                links[subdirectory] = new[] { linkPath };
+                links[subdirectory] = [linkPath];
             }
 
             var linkTask = new LinkTask(this.Logger, links, this.fileSystem);

--- a/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
@@ -91,8 +91,7 @@ namespace Cnct.Core.Tasks
                 this.fileSystem.Directory.Delete(linkPath);
             }
 
-            int lastSepIndex = linkPath.LastIndexOf(this.fileSystem.Path.DirectorySeparatorChar);
-            string destinationLinkDirectory = linkPath[..lastSepIndex];
+            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(this.fileSystem.Path.DirectorySeparatorChar)];
             if (!this.fileSystem.Directory.Exists(destinationLinkDirectory))
             {
                 this.fileSystem.Directory.CreateDirectory(destinationLinkDirectory);

--- a/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/LinkTask.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Abstractions;
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks
@@ -95,7 +91,8 @@ namespace Cnct.Core.Tasks
                 this.fileSystem.Directory.Delete(linkPath);
             }
 
-            string destinationLinkDirectory = linkPath[..linkPath.LastIndexOf(this.fileSystem.Path.DirectorySeparatorChar)];
+            int lastSepIndex = linkPath.LastIndexOf(this.fileSystem.Path.DirectorySeparatorChar);
+            string destinationLinkDirectory = linkPath[..lastSepIndex];
             if (!this.fileSystem.Directory.Exists(destinationLinkDirectory))
             {
                 this.fileSystem.Directory.CreateDirectory(destinationLinkDirectory);

--- a/Cnct/Cnct.Core/Tasks/Links/UnixSymlinkCreator.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/UnixSymlinkCreator.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace Cnct.Core.Tasks
 {
     internal class UnixSymlinkCreator : ISymlinkCreator

--- a/Cnct/Cnct.Core/Tasks/Links/WindowsSymlinkCreator.cs
+++ b/Cnct/Cnct.Core/Tasks/Links/WindowsSymlinkCreator.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace Cnct.Core.Tasks
 {
     internal class WindowsSymlinkCreator : ISymlinkCreator

--- a/Cnct/Cnct.Core/Tasks/ProcessGitRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/ProcessGitRunner.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks
 {
     public class ProcessGitRunner : IGitRunner
@@ -14,10 +10,10 @@ namespace Cnct.Core.Tasks
         }
 
         public Task CloneAsync(string url, string destination)
-            => this.RunGitProcessAsync(new[] { "clone", url, destination });
+            => this.RunGitProcessAsync(["clone", url, destination]);
 
         public Task PullAsync(string repositoryPath)
-            => this.RunGitProcessAsync(new[] { "-C", repositoryPath, "pull" });
+            => this.RunGitProcessAsync(["-C", repositoryPath, "pull"]);
 
         private async Task RunGitProcessAsync(string[] arguments)
         {

--- a/Cnct/Cnct.Core/Tasks/Shell/DefaultProcessRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/DefaultProcessRunner.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Diagnostics;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Cnct.Core.Tasks.Shell
 {

--- a/Cnct/Cnct.Core/Tasks/Shell/IProcessRunner.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/IProcessRunner.cs
@@ -1,6 +1,3 @@
-using System.Diagnostics;
-using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks.Shell
 {
     public interface IProcessRunner

--- a/Cnct/Cnct.Core/Tasks/Shell/IShellInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/IShellInvoker.cs
@@ -1,5 +1,3 @@
-﻿using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks.Shell
 {
     public interface IShellInvoker

--- a/Cnct/Cnct.Core/Tasks/Shell/PowerShellInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/PowerShellInvoker.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
-using System.Threading.Tasks;
 
 namespace Cnct.Core.Tasks.Shell
 {

--- a/Cnct/Cnct.Core/Tasks/Shell/ShInvoker.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShInvoker.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
-
 namespace Cnct.Core.Tasks.Shell
 {
     public class ShInvoker : IShellInvoker

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellExecutionOptions.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellExecutionOptions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Cnct.Core.Tasks.Shell
 {
     public class ShellExecutionOptions

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellInvokerFactory.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellInvokerFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using static Cnct.Core.Configuration.ShellTaskSpecification;
 
 namespace Cnct.Core.Tasks.Shell

--- a/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
+++ b/Cnct/Cnct.Core/Tasks/Shell/ShellTask.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Cnct.Core.Configuration;
 
 namespace Cnct.Core.Tasks.Shell

--- a/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
+++ b/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -24,6 +22,7 @@ namespace Cnct.Core.Validation
         [JsonPropertyName("issues")]
         public IReadOnlyList<ValidationIssue> Issues { get; }
 
-        public string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
+        public string ToJson() =>
+            System.Text.Json.JsonSerializer.Serialize(this, SerializerOptions);
     }
 }

--- a/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
+++ b/Cnct/Cnct.Core/Validation/ConfigValidationResult.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Cnct.Core.Validation
 {
@@ -22,7 +23,6 @@ namespace Cnct.Core.Validation
         [JsonPropertyName("issues")]
         public IReadOnlyList<ValidationIssue> Issues { get; }
 
-        public string ToJson() =>
-            System.Text.Json.JsonSerializer.Serialize(this, SerializerOptions);
+        public string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
     }
 }

--- a/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
+++ b/Cnct/Cnct.NetCore/Cnct.NetCore.csproj
@@ -37,7 +37,7 @@
   <PropertyGroup>
     <AssemblyName>Cnct</AssemblyName>
     <RootNamespace>Cnct</RootNamespace>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cnct/Cnct.NetCore/Program.cs
+++ b/Cnct/Cnct.NetCore/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Cnct.Core;
 
 namespace Cnct

--- a/Cnct/Cnct.NetCore/Program.cs
+++ b/Cnct/Cnct.NetCore/Program.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Cnct.Core;
 
 namespace Cnct

--- a/Cnct/Cnct.SourceGeneration/Cnct.SourceGeneration.csproj
+++ b/Cnct/Cnct.SourceGeneration/Cnct.SourceGeneration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
 	<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 

--- a/Cnct/Directory.Packages.props
+++ b/Cnct/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.15" />


### PR DESCRIPTION
## Summary

Modernize C# syntax across all projects after upgrading to LangVersion 12.0. Net reduction of **238 lines** (108 added, 346 removed).

## Changes

### Project configuration
- **LangVersion** to 12.0 in Cnct.NetCore (was 7.3) and Cnct.SourceGeneration (was 9.0); Cnct.Core was already at 12.0
- **StyleCop.Analyzers** upgraded from 1.1.118 to 1.2.0-beta.556 for C# 12 compatibility

### Collection expressions (C# 12)
- `Array.Empty<T>()`, `new[] { ... }`, and `new T[] { ... }` replaced with `[...]`
- Applied across Cnct.Core and Cnct.Core.Tests

### Switch expressions (C# 8)
- Converted remaining `switch` statements to switch expressions in `Platform.cs`, `LinkCollectionConverter.cs`, and `MachineSettingsLoader.cs`

### Target-typed `new()` (C# 9)
- Replaced explicit constructor types with `new()` where the target type is clear from context (`MachineSettings.cs`, `Platform.cs`, `ShellInvokerFactoryTests.cs`)

### Global usings (C# 10)
- Added `GlobalUsings.cs` to Cnct.Core (10 usings) and Cnct.Core.Tests (9 usings)
- Removed ~218 individual `using` directives from source files

### Docs
- Updated copilot instructions: feature PRs must target `develop`

## Verification
- Build: 0 errors, 0 warnings
- Tests: 100/100 passed