### PR TITLE
Make validation machine-aware to skip filesystem checks for non-matching actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixes
+
+* Validation is now aware of the current machine's tags and operating system.
+  Machine-dependent checks (e.g. filesystem existence for `link`, `copy`, and
+  `linkExpand` sources) are skipped for any action whose `tags` or `os` filter
+  excludes the current machine, so validating a config on one machine no
+  longer reports false-positive errors for actions that target a different
+  machine. Pure-config checks (required fields, URL format, etc.) continue
+  to run for every action.
+
 ## 0.6.0
 
 ### Feature updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@
 
 ### Fixes
 
-* Validation is now aware of the current machine's tags and operating system.
-  Machine-dependent checks (e.g. filesystem existence for `link`, `copy`, and
-  `linkExpand` sources) are skipped for any action whose `tags` or `os` filter
-  excludes the current machine, so validating a config on one machine no
-  longer reports false-positive errors for actions that target a different
-  machine. Pure-config checks (required fields, URL format, etc.) continue
-  to run for every action.
+* Validation is now aware of whether an action would run on the current machine
+  and skips any machine-dependent checks, e.g. checking whether source files and
+  directories exist for `link`, `copy`, and `linkExpand` actions. This eliminates
+  false-positive validation errors that would prevent taking action for an entire
+  configuration.
 
 ## 0.6.0
 

--- a/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CloneGitRepositoryTaskSpecificationTests.cs
@@ -55,7 +55,7 @@ namespace Cnct.Core.Tests
         {
             var spec = new CloneGitRepositoryTaskSpecification { Repos = null };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
@@ -68,7 +68,7 @@ namespace Cnct.Core.Tests
                 Repos = new Dictionary<string, string>(),
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
@@ -84,7 +84,7 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.DoesNotContain(issues, i => i.Severity == ValidationSeverity.Error);
         }
@@ -103,7 +103,7 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
@@ -161,7 +161,7 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Empty(issues);
         }
@@ -177,7 +177,7 @@ namespace Cnct.Core.Tests
                 },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Single(issues);
             Assert.Equal(ValidationSeverity.Error, issues[0].Severity);

--- a/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CopyTaskSpecificationTests.cs
@@ -47,7 +47,7 @@ namespace Cnct.Core.Tests
                 Files = new Dictionary<string, object> { [sourceFile] = "~/destination" },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
 
             Assert.Empty(issues);
         }
@@ -65,11 +65,62 @@ namespace Cnct.Core.Tests
                 Files = new Dictionary<string, object> { [sourceFile] = "~/destination" },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
 
             Assert.Single(issues);
             Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
             Assert.Contains("does not exist", issues[0].Message);
+        }
+
+        [Fact]
+        public void Validate_SkipsSourceExistenceCheck_WhenActionTagsDoNotMatchMachineTags()
+        {
+            var mockFs = new MockFileSystem();
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = new Dictionary<string, object> { ["missing-file"] = "~/destination" },
+                Tags = ["work"],
+            };
+
+            IReadOnlyList<ValidationIssue> issues =
+                spec.Validate(new CnctContext("/config", ["personal"]));
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_SkipsSourceExistenceCheck_WhenPlatformDoesNotMatch()
+        {
+            var mockFs = new MockFileSystem();
+            PlatformType otherPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = new Dictionary<string, object> { ["missing-file"] = "~/destination" },
+                PlatformType = [otherPlatform],
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_StillReportsEmptyFiles_WhenActionWouldBeSkipped()
+        {
+            var mockFs = new MockFileSystem();
+            var spec = new CopyTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Files = null,
+                Tags = ["work"],
+            };
+
+            IReadOnlyList<ValidationIssue> issues =
+                spec.Validate(new CnctContext("/config", ["personal"]));
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/EnvironmentVariableSpecificationTests.cs
@@ -46,7 +46,7 @@ namespace Cnct.Core.Tests
                 Value = "hello",
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Empty(issues);
         }
@@ -60,7 +60,7 @@ namespace Cnct.Core.Tests
                 Value = "hello",
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Single(issues);
             Assert.Equal(ValidationSeverity.Error, issues[0].Severity);

--- a/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkExpandTaskSpecificationTests.cs
@@ -37,7 +37,7 @@ namespace Cnct.Core.Tests
                 Target = "~/some/target",
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("source"));
         }
@@ -55,7 +55,7 @@ namespace Cnct.Core.Tests
                 Target = target,
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("target"));
         }
@@ -84,7 +84,7 @@ namespace Cnct.Core.Tests
                 Target = "~/some/target",
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
 
             Assert.Empty(issues);
         }
@@ -103,11 +103,70 @@ namespace Cnct.Core.Tests
                 Target = "~/some/target",
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
 
             Assert.Single(issues);
             Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
             Assert.Contains("does not exist", issues[0].Message);
+        }
+
+        [Fact]
+        public void Validate_SkipsSourceExistenceCheck_WhenActionTagsDoNotMatchMachineTags()
+        {
+            const string configRoot = "/config";
+            var mockFs = new MockFileSystem();
+
+            var spec = new LinkExpandTaskSpecification(mockFs, new PathResolver(mockFs))
+            {
+                Source = "missing-scripts",
+                Target = "~/some/target",
+                Tags = ["work"],
+            };
+
+            IReadOnlyList<ValidationIssue> issues =
+                spec.Validate(new CnctContext(configRoot, ["personal"]));
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_SkipsSourceExistenceCheck_WhenPlatformDoesNotMatch()
+        {
+            const string configRoot = "/config";
+            var mockFs = new MockFileSystem();
+
+            PlatformType otherPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+
+            var spec = new LinkExpandTaskSpecification(mockFs, new PathResolver(mockFs))
+            {
+                Source = "missing-scripts",
+                Target = "~/some/target",
+                PlatformType = [otherPlatform],
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_StillReportsConfigErrors_WhenActionWouldBeSkipped()
+        {
+            var mockFs = new MockFileSystem();
+
+            var spec = new LinkExpandTaskSpecification(mockFs, new PathResolver(mockFs))
+            {
+                Source = null,
+                Target = "~/some/target",
+                Tags = ["work"],
+            };
+
+            IReadOnlyList<ValidationIssue> issues =
+                spec.Validate(new CnctContext("/config", ["personal"]));
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error && i.Message.Contains("source"));
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/LinkTaskSpecificationTests.cs
@@ -47,7 +47,7 @@ namespace Cnct.Core.Tests
                 Links = new Dictionary<string, object> { [sourceFile] = "~/destination" },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
 
             Assert.Empty(issues);
         }
@@ -65,11 +65,62 @@ namespace Cnct.Core.Tests
                 Links = new Dictionary<string, object> { [sourceFile] = "~/destination" },
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate(configRoot);
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext(configRoot, []));
 
             Assert.Single(issues);
             Assert.Equal(ValidationSeverity.Error, issues[0].Severity);
             Assert.Contains("does not exist", issues[0].Message);
+        }
+
+        [Fact]
+        public void Validate_SkipsSourceExistenceCheck_WhenActionTagsDoNotMatchMachineTags()
+        {
+            var mockFs = new MockFileSystem();
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = new Dictionary<string, object> { ["missing-file"] = "~/destination" },
+                Tags = ["work"],
+            };
+
+            IReadOnlyList<ValidationIssue> issues =
+                spec.Validate(new CnctContext("/config", ["personal"]));
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_SkipsSourceExistenceCheck_WhenPlatformDoesNotMatch()
+        {
+            var mockFs = new MockFileSystem();
+            PlatformType otherPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = new Dictionary<string, object> { ["missing-file"] = "~/destination" },
+                PlatformType = [otherPlatform],
+            };
+
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
+
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Validate_StillReportsEmptyLinks_WhenActionWouldBeSkipped()
+        {
+            var mockFs = new MockFileSystem();
+            var spec = new LinkTaskSpecification(new Configuration.FileManagement(), mockFs)
+            {
+                Links = null,
+                Tags = ["work"],
+            };
+
+            IReadOnlyList<ValidationIssue> issues =
+                spec.Validate(new CnctContext("/config", ["personal"]));
+
+            Assert.Contains(issues, i => i.Severity == ValidationSeverity.Error);
         }
     }
 }

--- a/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
+++ b/Cnct/Cnct.Core.Tests/ShellTaskSpecificationTests.cs
@@ -132,7 +132,7 @@ namespace Cnct.Core.Tests
                 Command = "echo hello",
             };
 
-            IReadOnlyList<ValidationIssue> issues = spec.Validate("/config");
+            IReadOnlyList<ValidationIssue> issues = spec.Validate(new CnctContext("/config", []));
 
             // The result depends on whether pwsh is installed — just verify the shape
             // If pwsh is not on PATH, we expect a warning; if it is, we expect no issues.

--- a/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CloneGitRepositoryTaskSpecification.cs
@@ -8,7 +8,7 @@ namespace Cnct.Core.Configuration
         [JsonProperty("repos")]
         public IReadOnlyDictionary<string, string> Repos { get; set; }
 
-        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public override IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             var issues = new List<ValidationIssue>();
             if (this.Repos == null || this.Repos.Count == 0)

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -37,9 +37,26 @@ namespace Cnct.Core.Configuration
                 || this.PlatformType.Contains(Platform.CurrentPlatform);
         }
 
-        public virtual IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public virtual IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             return [];
+        }
+
+        protected bool WouldRunOnCurrentMachine(CnctContext context)
+        {
+            if (context == null)
+            {
+                return true;
+            }
+
+            if (this.Tags != null
+                && this.Tags.Count > 0
+                && !this.Tags.Any(t => context.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            return this.ShouldExecuteOnCurrentPlatform();
         }
 
         protected ValidationIssue CreateValidationError(string message)

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -35,9 +35,10 @@ namespace Cnct.Core.Configuration
             }
 
             var issues = new List<ValidationIssue>();
+            var context = new CnctContext(this.ConfigRootDirectory, this.MachineTags);
             foreach (var action in this.Actions.Where(a => a != null))
             {
-                issues.AddRange(action.Validate(this.ConfigRootDirectory));
+                issues.AddRange(action.Validate(context));
             }
 
             return new ConfigValidationResult(issues);

--- a/Cnct/Cnct.Core/Configuration/CnctContext.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctContext.cs
@@ -1,0 +1,15 @@
+namespace Cnct.Core.Configuration
+{
+    public sealed class CnctContext
+    {
+        public CnctContext(string configDirectoryRoot, IReadOnlyCollection<string> machineTags)
+        {
+            this.ConfigDirectoryRoot = configDirectoryRoot;
+            this.MachineTags = machineTags ?? [];
+        }
+
+        public string ConfigDirectoryRoot { get; }
+
+        public IReadOnlyCollection<string> MachineTags { get; }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/CopyTaskSpecification.cs
@@ -22,7 +22,7 @@ namespace Cnct.Core.Configuration
         {
         }
 
-        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public override IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             var issues = new List<ValidationIssue>();
             if (this.Files == null || this.Files.Count == 0)
@@ -31,7 +31,13 @@ namespace Cnct.Core.Configuration
                 return issues;
             }
 
-            foreach (string sourcePath in this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Files).Keys)
+            if (!this.WouldRunOnCurrentMachine(context))
+            {
+                return issues;
+            }
+
+            foreach (string sourcePath in
+                this.fileManagement.GetFileConfigurations(context.ConfigDirectoryRoot, this.Files).Keys)
             {
                 if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
                 {

--- a/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/EnvironmentVariableTaskSpecification.cs
@@ -11,7 +11,7 @@ namespace Cnct.Core.Configuration
         [JsonRequired]
         public string Value { get; set; }
 
-        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public override IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             var issues = new List<ValidationIssue>();
             if (!string.IsNullOrEmpty(this.Name) && this.Name.Contains('='))

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -13,6 +13,6 @@ namespace Cnct.Core.Configuration
 
         bool ShouldExecuteOnCurrentPlatform();
 
-        IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot);
+        IReadOnlyList<ValidationIssue> Validate(CnctContext context);
     }
 }

--- a/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkExpandTaskSpecification.cs
@@ -27,7 +27,7 @@ namespace Cnct.Core.Configuration
         [JsonProperty("target")]
         public string Target { get; set; }
 
-        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public override IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             var issues = new List<ValidationIssue>();
             if (string.IsNullOrWhiteSpace(this.Source))
@@ -40,9 +40,9 @@ namespace Cnct.Core.Configuration
                 issues.Add(this.CreateValidationError("A target directory must be specified."));
             }
 
-            if (issues.Count == 0)
+            if (issues.Count == 0 && this.WouldRunOnCurrentMachine(context))
             {
-                string source = this.pathResolver.Resolve(this.Source, configDirectoryRoot);
+                string source = this.pathResolver.Resolve(this.Source, context.ConfigDirectoryRoot);
                 if (!this.fileSystem.Directory.Exists(source))
                 {
                     issues.Add(this.CreateValidationError($"Source directory does not exist: {source}"));

--- a/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/LinkTaskSpecification.cs
@@ -22,7 +22,7 @@ namespace Cnct.Core.Configuration
         [JsonConverter(typeof(FileSpecificationCollectionConverter))]
         public IReadOnlyDictionary<string, object> Links { get; set; }
 
-        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public override IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             var issues = new List<ValidationIssue>();
             if (this.Links == null || this.Links.Count == 0)
@@ -31,7 +31,13 @@ namespace Cnct.Core.Configuration
                 return issues;
             }
 
-            foreach (string sourcePath in this.fileManagement.GetFileConfigurations(configDirectoryRoot, this.Links).Keys)
+            if (!this.WouldRunOnCurrentMachine(context))
+            {
+                return issues;
+            }
+
+            foreach (string sourcePath in
+                this.fileManagement.GetFileConfigurations(context.ConfigDirectoryRoot, this.Links).Keys)
             {
                 if (!this.fileSystem.File.Exists(sourcePath) && !this.fileSystem.Directory.Exists(sourcePath))
                 {

--- a/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
+++ b/Cnct/Cnct.Core/Configuration/ShellTaskSpecification.cs
@@ -13,7 +13,7 @@ namespace Cnct.Core.Configuration
 
         public bool Silent { get; set; }
 
-        public override IReadOnlyList<ValidationIssue> Validate(string configDirectoryRoot)
+        public override IReadOnlyList<ValidationIssue> Validate(CnctContext context)
         {
             var issues = new List<ValidationIssue>();
             if (this.Shell == ShellType.Unknown)


### PR DESCRIPTION
## Summary

Validation is now aware of whether an action would run on the current machine
and skips any machine-dependent checks, e.g. checking whether source files and
directories exist for `link`, `copy`, and `linkExpand` actions. This eliminates
false-positive validation errors that would prevent taking action for an entire
configuration.

## Changes

- **New `CnctContext`** - generic context object carrying `ConfigDirectoryRoot` + `MachineTags`, extensible for future use beyond validation.
- **`ICnctActionSpec.Validate(CnctContext)`** - updated signature from `Validate(string configDirectoryRoot)`.
- **`CnctActionSpecBase.WouldRunOnCurrentMachine(context)`** - helper that mirrors `CnctConfig.ExecuteAsync`'s tag + platform skip logic.
- **`LinkExpand`/`Link`/`Copy`** - filesystem existence checks gated behind `WouldRunOnCurrentMachine`; config-only checks still run unconditionally.
- **`CloneGitRepository`/`Shell`/`EnvironmentVariable`** - adopt new signature (no machine-dependent checks to gate).
- **`CnctConfig.Validate`** - builds `CnctContext` from `ConfigRootDirectory` + `MachineTags`.

## Testing

- All existing tests migrated to `CnctContext`.
- 12 new tests covering tag-mismatch, platform-mismatch, and config errors still reported when action would be skipped for LinkExpand, Link, and Copy.
- **109/109 tests pass**, 0 warnings, 0 errors.
