### PR TITLE
Add --action CLI option to run specific named actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,9 @@
 
 ### Feature updates
 
-* Add optional `"id"` property to actions in `cnct.json`. Each action can now
-  be given a unique identifier for targeted execution.
 * Add `--action` / `-a` CLI option to run only the action(s) with the
-  specified id(s). Can be specified multiple times
-  (e.g. `cnct --action foo --action bar`). OS and tag filtering still applies
-  — an action that would not run on the current machine is skipped even when
-  explicitly targeted.
-* Duplicate action ids within the same config are now a validation error.
+  specified id(s), e.g. `cnct --action foo --action bar`. Each action
+  can now be given a unique identifier for targeted execution.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Feature updates
+
+* Add optional `"id"` property to actions in `cnct.json`. Each action can now
+  be given a unique identifier for targeted execution.
+* Add `--action` / `-a` CLI option to run only the action(s) with the
+  specified id(s). Can be specified multiple times
+  (e.g. `cnct --action foo --action bar`). OS and tag filtering still applies
+  — an action that would not run on the current machine is skipped even when
+  explicitly targeted.
+* Duplicate action ids within the same config are now a validation error.
+
 ### Fixes
 
 * Validation is now aware of whether an action would run on the current machine

--- a/Cnct/Cnct.Core.Tests/CnctRunnerActionFilterTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctRunnerActionFilterTests.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cnct.Core.Configuration;
+using Cnct.Core.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class CnctRunnerActionFilterTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_RunsOnlyMatchingAction_WhenActionFilterIsSet()
+        {
+            var targetAction = new TestActionSpec { ID = "target" };
+            var otherAction = new TestActionSpec { ID = "other" };
+            var (runner, actionRunner) = MakeRunner([], ["target"], targetAction, otherAction);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(targetAction, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+            actionRunner.Verify(
+                r => r.ExecuteAsync(otherAction, It.IsAny<ILogger>(), It.IsAny<string>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsMultipleMatchingActions_WhenMultipleIdsInFilter()
+        {
+            var actionA = new TestActionSpec { ID = "a" };
+            var actionB = new TestActionSpec { ID = "b" };
+            var actionC = new TestActionSpec { ID = "c" };
+            var (runner, actionRunner) = MakeRunner([], ["a", "c"], actionA, actionB, actionC);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(actionA, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+            actionRunner.Verify(
+                r => r.ExecuteAsync(actionB, It.IsAny<ILogger>(), It.IsAny<string>()),
+                Times.Never);
+            actionRunner.Verify(
+                r => r.ExecuteAsync(actionC, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_MatchesActionIdCaseInsensitively()
+        {
+            var action = new TestActionSpec { ID = "My-Action" };
+            var (runner, actionRunner) = MakeRunner([], ["my-action"], action);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SkipsUnnamedActions_WhenActionFilterIsSet()
+        {
+            var namedAction = new TestActionSpec { ID = "named" };
+            var unnamedAction = new TestActionSpec();
+            var (runner, actionRunner) = MakeRunner([], ["named"], namedAction, unnamedAction);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(namedAction, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+            actionRunner.Verify(
+                r => r.ExecuteAsync(unnamedAction, It.IsAny<ILogger>(), It.IsAny<string>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_StillSkipsAction_WhenOsDoesNotMatch()
+        {
+            var nonCurrentPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+            var action = new TestActionSpec
+            {
+                ID = "os-limited",
+                PlatformType = [nonCurrentPlatform],
+            };
+            var (runner, actionRunner) = MakeRunner([], ["os-limited"], action);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ICnctActionSpec>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<string>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_StillSkipsAction_WhenTagsDoNotMatch()
+        {
+            var action = new TestActionSpec
+            {
+                ID = "tagged",
+                Tags = ["personal"],
+            };
+            var (runner, actionRunner) = MakeRunner(["work"], ["tagged"], action);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(
+                    It.IsAny<ICnctActionSpec>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<string>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_LogsError_WhenRequestedIdNotFound()
+        {
+            var logger = new Mock<ILogger>();
+            var actionRunner = new Mock<IActionRunner>();
+            var action = new TestActionSpec { ID = "exists" };
+            var config = new CnctConfig { Actions = [action] };
+            var runner = new CnctRunner(
+                config, logger.Object, "/", [], actionRunner.Object, ["does-not-exist"]);
+
+            await runner.ExecuteAsync();
+
+            logger.Verify(
+                l => l.LogError(
+                    It.Is<string>(s => s.Contains("does-not-exist") && s.Contains("not found")),
+                    null),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RunsAllActions_WhenActionFilterIsEmpty()
+        {
+            var actionA = new TestActionSpec { ID = "a" };
+            var actionB = new TestActionSpec { ID = "b" };
+            var (runner, actionRunner) = MakeRunner([], [], actionA, actionB);
+
+            await runner.ExecuteAsync();
+
+            actionRunner.Verify(
+                r => r.ExecuteAsync(actionA, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+            actionRunner.Verify(
+                r => r.ExecuteAsync(actionB, It.IsAny<ILogger>(), "/"),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_DoesNotLogNotFound_WhenOsSkippedNamedAction()
+        {
+            var nonCurrentPlatform = Platform.CurrentPlatform == PlatformType.Windows
+                ? PlatformType.Linux
+                : PlatformType.Windows;
+            var logger = new Mock<ILogger>();
+            var actionRunner = new Mock<IActionRunner>();
+            var action = new TestActionSpec
+            {
+                ID = "os-limited",
+                PlatformType = [nonCurrentPlatform],
+            };
+            var config = new CnctConfig { Actions = [action] };
+            var runner = new CnctRunner(
+                config, logger.Object, "/", [], actionRunner.Object, ["os-limited"]);
+
+            await runner.ExecuteAsync();
+
+            logger.Verify(
+                l => l.LogError(
+                    It.Is<string>(s => s.Contains("not found")),
+                    null),
+                Times.Never);
+        }
+
+        [Fact]
+        public void IdProperty_IsDeserialized_FromJson()
+        {
+            var json = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["actionType"] = "link",
+                ["id"] = "my-links",
+                ["links"] = new Dictionary<string, string> { ["a"] = "b" },
+            });
+
+            var spec = JsonConvert.DeserializeObject<ICnctActionSpec>(json);
+
+            Assert.Equal("my-links", spec.ID);
+        }
+
+        private static (CnctRunner Runner, Mock<IActionRunner> ActionRunner) MakeRunner(
+            IReadOnlyCollection<string> machineTags,
+            IReadOnlyCollection<string> actionFilter,
+            params ICnctActionSpec[] actions)
+        {
+            var actionRunner = new Mock<IActionRunner>();
+            var config = new CnctConfig { Actions = actions };
+            var runner = new CnctRunner(
+                config, Mock.Of<ILogger>(), "/", machineTags, actionRunner.Object, actionFilter);
+
+            return (runner, actionRunner);
+        }
+
+        private class TestActionSpec : CnctActionSpecBase
+        {
+            public override string ActionType => "test";
+        }
+    }
+}

--- a/Cnct/Cnct.Core.Tests/CnctRunnerDuplicateIdValidationTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctRunnerDuplicateIdValidationTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cnct.Core.Configuration;
+using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
+using Moq;
+using Xunit;
+
+namespace Cnct.Core.Tests
+{
+    public class CnctRunnerDuplicateIdValidationTests
+    {
+        [Fact]
+        public void Validate_ReturnsError_WhenDuplicateIdsExist()
+        {
+            var runner = MakeRunner(new TestActionSpec { ID = "my-action" }, new TestActionSpec { ID = "my-action" });
+
+            ConfigValidationResult result = runner.Validate();
+
+            Assert.False(result.IsValid);
+            Assert.Contains(
+                result.Issues,
+                i => i.Severity == ValidationSeverity.Error
+                    && i.Message.Contains("Duplicate action id 'my-action'"));
+        }
+
+        [Fact]
+        public void Validate_ReturnsError_WhenDuplicateIdsCaseInsensitive()
+        {
+            var runner = MakeRunner(
+                new TestActionSpec { ID = "My-Action" }, new TestActionSpec { ID = "my-action" });
+
+            ConfigValidationResult result = runner.Validate();
+
+            Assert.False(result.IsValid);
+            Assert.Single(
+                result.Issues,
+                i => i.Severity == ValidationSeverity.Error);
+        }
+
+        [Fact]
+        public void Validate_Succeeds_WhenIdsAreUnique()
+        {
+            var runner = MakeRunner(
+                new TestActionSpec { ID = "action-a" }, new TestActionSpec { ID = "action-b" });
+
+            ConfigValidationResult result = runner.Validate();
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void Validate_Succeeds_WhenMultipleActionsHaveNoId()
+        {
+            var runner = MakeRunner(new TestActionSpec(), new TestActionSpec());
+
+            ConfigValidationResult result = runner.Validate();
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void Validate_Succeeds_WhenMixOfNamedAndUnnamedActions()
+        {
+            var runner = MakeRunner(
+                new TestActionSpec { ID = "my-action" }, new TestActionSpec(), new TestActionSpec());
+
+            ConfigValidationResult result = runner.Validate();
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void Validate_ReportsMultipleDuplicateGroups()
+        {
+            var runner = MakeRunner(
+                new TestActionSpec { ID = "alpha" },
+                new TestActionSpec { ID = "alpha" },
+                new TestActionSpec { ID = "beta" },
+                new TestActionSpec { ID = "beta" });
+
+            ConfigValidationResult result = runner.Validate();
+
+            Assert.False(result.IsValid);
+            Assert.Equal(
+                2,
+                result.Issues.Count(i => i.Severity == ValidationSeverity.Error
+                    && i.Message.Contains("Duplicate action id")));
+        }
+
+        private static CnctRunner MakeRunner(params ICnctActionSpec[] actions)
+        {
+            var config = new CnctConfig { Actions = actions };
+            return new CnctRunner(
+                config, Mock.Of<ILogger>(), "/", [], Mock.Of<IActionRunner>());
+        }
+
+        private class TestActionSpec : CnctActionSpecBase
+        {
+            public override string ActionType => "test";
+        }
+    }
+}

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -13,7 +13,8 @@ namespace Cnct.Core
             var rootCommand = new RootCommand
             {
                 Description = "A cross-platform bootstrapping tool. Connect your dotfiles / cnct the dots!",
-                Handler = CommandHandler.Create((Func<FileInfo, bool, bool, bool, Task<int>>)ExecuteAsync),
+                Handler = CommandHandler.Create(
+                    (Func<FileInfo, bool, bool, bool, string[], Task<int>>)ExecuteAsync),
             };
 
             string configOptDescription = "Path to a configuration file. If not supplied, a file called 'cnct.json' "
@@ -24,6 +25,10 @@ namespace Cnct.Core
                 CreateOption<bool>('q', "quiet", "Suppress all output other than errors."),
                 CreateOption<bool>('d', "debug", "Output additional debug information."),
                 CreateOption<bool>('v', "validate", "Validate the config file and output results as JSON."),
+                CreateOption<string[]>(
+                    'a',
+                    "action",
+                    "Run only the action(s) with the specified id. Can be specified multiple times."),
             };
 
             foreach (var option in options)
@@ -34,7 +39,12 @@ namespace Cnct.Core
             return await rootCommand.InvokeAsync(args);
         }
 
-        private static async Task<int> ExecuteAsync(FileInfo config, bool quiet, bool debug, bool validate)
+        private static async Task<int> ExecuteAsync(
+            FileInfo config,
+            bool quiet,
+            bool debug,
+            bool validate,
+            string[] action)
         {
             var logger = new ConsoleLogger(new LoggerOptions(quiet, debug));
             var parser = new CnctConfigurationParser(logger);
@@ -46,7 +56,7 @@ namespace Cnct.Core
             IReadOnlyCollection<string> machineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
 
             var runner = new CnctRunner(
-                cnctConfig, logger, configRootDirectory, machineTags, new ActionRunner());
+                cnctConfig, logger, configRootDirectory, machineTags, new ActionRunner(), action ?? []);
 
             ConfigValidationResult validation = runner.Validate();
             if (validate)

--- a/Cnct/Cnct.Core/CnctRunner.cs
+++ b/Cnct/Cnct.Core/CnctRunner.cs
@@ -81,15 +81,13 @@ namespace Cnct.Core
                 string skipReason = this.GetSkipReason(action, hasActionFilter, matchedIds);
                 if (skipReason != null)
                 {
-                    this.logger.LogVerbose(
-                        $"Skipping action '{action.GetDisplayText()}': {skipReason}.");
+                    this.logger.LogVerbose($"Skipping action '{action.GetDisplayText()}': {skipReason}.");
                     continue;
                 }
 
-                string displayText = action.GetDisplayText();
-
                 try
                 {
+                    string displayText = action.GetDisplayText();
                     var start = DateTimeOffset.Now;
                     this.logger.LogStart(displayText);
 
@@ -121,10 +119,7 @@ namespace Cnct.Core
             return true;
         }
 
-        private string GetSkipReason(
-            ICnctActionSpec action,
-            bool hasActionFilter,
-            HashSet<string> matchedIds)
+        private string GetSkipReason(ICnctActionSpec action, bool hasActionFilter, HashSet<string> matchedIds)
         {
             if (hasActionFilter)
             {

--- a/Cnct/Cnct.Core/CnctRunner.cs
+++ b/Cnct/Cnct.Core/CnctRunner.cs
@@ -11,19 +11,22 @@ namespace Cnct.Core
         private readonly string configRootDirectory;
         private readonly IReadOnlyCollection<string> machineTags;
         private readonly IActionRunner runner;
+        private readonly IReadOnlyCollection<string> actionFilter;
 
         public CnctRunner(
             CnctConfig config,
             ILogger logger,
             string configRootDirectory,
             IReadOnlyCollection<string> machineTags,
-            IActionRunner runner)
+            IActionRunner runner,
+            IReadOnlyCollection<string> actionFilter = null)
         {
             this.config = config;
             this.logger = logger;
             this.configRootDirectory = configRootDirectory;
             this.machineTags = machineTags;
             this.runner = runner;
+            this.actionFilter = actionFilter ?? [];
         }
 
         public ConfigValidationResult Validate()
@@ -42,9 +45,27 @@ namespace Cnct.Core
 
             var issues = new List<ValidationIssue>();
             var context = new CnctContext(this.configRootDirectory, this.machineTags);
+            var seenIds = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             foreach (var action in this.config.Actions.Where(a => a != null))
             {
                 issues.AddRange(action.Validate(context));
+
+                if (!string.IsNullOrEmpty(action.ID))
+                {
+                    if (!seenIds.TryAdd(action.ID, 1))
+                    {
+                        seenIds[action.ID]++;
+                    }
+                }
+            }
+
+            foreach (var entry in seenIds.Where(e => e.Value > 1))
+            {
+                issues.Add(new ValidationIssue(
+                    ValidationSeverity.Error,
+                    "config",
+                    null,
+                    $"Duplicate action id '{entry.Key}' found on {entry.Value} actions."));
             }
 
             return new ConfigValidationResult(issues);
@@ -52,19 +73,27 @@ namespace Cnct.Core
 
         public async Task<bool> ExecuteAsync()
         {
+            bool hasActionFilter = this.actionFilter.Count > 0;
+            var matchedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
             foreach (var action in this.config.Actions.Where(a => a != null))
             {
-                if (action.Tags.Any()
-                    && !action.Tags.Any(t => this.machineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                if (hasActionFilter)
                 {
-                    this.logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
-                    continue;
+                    if (string.IsNullOrEmpty(action.ID)
+                        || !this.actionFilter.Contains(action.ID, StringComparer.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    matchedIds.Add(action.ID);
                 }
 
-                if (!action.ShouldExecuteOnCurrentPlatform())
+                string skipReason = this.GetSkipReason(action);
+                if (skipReason != null)
                 {
                     this.logger.LogVerbose(
-                        $"Skipping action '{action.ActionType}': not applicable to current OS.");
+                        $"Skipping action '{action.GetDisplayText()}': {skipReason}.");
                     continue;
                 }
 
@@ -89,7 +118,34 @@ namespace Cnct.Core
                 }
             }
 
+            if (hasActionFilter)
+            {
+                foreach (var id in this.actionFilter)
+                {
+                    if (!matchedIds.Contains(id))
+                    {
+                        this.logger.LogError($"Action with id '{id}' was not found in the configuration.");
+                    }
+                }
+            }
+
             return true;
+        }
+
+        private string GetSkipReason(ICnctActionSpec action)
+        {
+            if (action.Tags.Any()
+                && !action.Tags.Any(t => this.machineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+            {
+                return "no matching machine tag";
+            }
+
+            if (!action.ShouldExecuteOnCurrentPlatform())
+            {
+                return "not applicable to current OS";
+            }
+
+            return null;
         }
     }
 }

--- a/Cnct/Cnct.Core/CnctRunner.cs
+++ b/Cnct/Cnct.Core/CnctRunner.cs
@@ -78,18 +78,7 @@ namespace Cnct.Core
 
             foreach (var action in this.config.Actions.Where(a => a != null))
             {
-                if (hasActionFilter)
-                {
-                    if (string.IsNullOrEmpty(action.ID)
-                        || !this.actionFilter.Contains(action.ID, StringComparer.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    matchedIds.Add(action.ID);
-                }
-
-                string skipReason = this.GetSkipReason(action);
+                string skipReason = this.GetSkipReason(action, hasActionFilter, matchedIds);
                 if (skipReason != null)
                 {
                     this.logger.LogVerbose(
@@ -132,8 +121,22 @@ namespace Cnct.Core
             return true;
         }
 
-        private string GetSkipReason(ICnctActionSpec action)
+        private string GetSkipReason(
+            ICnctActionSpec action,
+            bool hasActionFilter,
+            HashSet<string> matchedIds)
         {
+            if (hasActionFilter)
+            {
+                if (string.IsNullOrEmpty(action.ID)
+                    || !this.actionFilter.Contains(action.ID, StringComparer.OrdinalIgnoreCase))
+                {
+                    return "not targeted by --action filter";
+                }
+
+                matchedIds.Add(action.ID);
+            }
+
             if (action.Tags.Any()
                 && !action.Tags.Any(t => this.machineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
             {

--- a/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctActionSpecBase.cs
@@ -4,6 +4,9 @@ namespace Cnct.Core.Configuration
 {
     public abstract class CnctActionSpecBase : ICnctActionSpec
     {
+        [JsonProperty("id")]
+        public string ID { get; set; }
+
         [JsonProperty("label")]
         public string Label { get; set; }
 

--- a/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
+++ b/Cnct/Cnct.Core/Configuration/ICnctActionSpec.cs
@@ -5,6 +5,8 @@ namespace Cnct.Core.Configuration
     [JsonConverter(typeof(CnctActionConverter))]
     public interface ICnctActionSpec
     {
+        string ID { get; }
+
         string ActionType { get; }
 
         IReadOnlyCollection<string> Tags { get; }

--- a/schema/cnctConfig.vnext.json
+++ b/schema/cnctConfig.vnext.json
@@ -69,6 +69,10 @@
                     "description": "The type of the action.",
                     "type": "string"
                 },
+                "id": {
+                    "description": "An optional unique identifier for the action. Used with the --action CLI option to run specific actions by name.",
+                    "type": "string"
+                },
                 "description": {
                     "description": "A description for the action.",
                     "type": "string"


### PR DESCRIPTION
## Summary

Add optional `id` property to actions in `cnct.json` and a new `--action` / `-a` CLI option to run only targeted actions by id.

## Changes

- **`id` property** — optional string on each action (distinct from `label`), used as a stable machine-readable identifier
- **`--action` / `-a` CLI option** — accepts multiple values (e.g. `cnct --action foo --action bar`) to run only matching actions
- **OS/tag filtering honored** — a targeted action that wouldn't run on the current machine (wrong OS or missing tags) is still skipped
- **Duplicate id validation** — duplicate non-empty ids (case-insensitive) in the same config produce a validation error
- **Unknown id error** — if a requested id is not found in the config, an error is logged
- **JSON schema** — `id` added to `ActionBase` in `cnctConfig.vnext.json`
- **Changelog** — documented under Unreleased

## Tests

16 new tests covering:
- Duplicate id validation (6 tests): exact duplicates, case-insensitive, unique ids, null ids, mixed, multiple groups
- Action filtering (10 tests): single/multiple filter, case-insensitive match, unnamed skipped, OS honored, tags honored, unknown id error, empty filter runs all, OS-skipped not reported missing, deserialization round-trip
