### PR TITLE
Refactor: split CnctConfig into data model and CnctRunner

### DIFF
--- a/Cnct/Cnct.Core.Tests/CnctRunnerTests.cs
+++ b/Cnct/Cnct.Core.Tests/CnctRunnerTests.cs
@@ -8,17 +8,17 @@ using Xunit;
 
 namespace Cnct.Core.Tests
 {
-    public class CnctConfigTagFilteringTests
+    public class CnctRunnerTests
     {
         [Fact]
         public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasNoTags()
         {
             var action = new TestActionSpec();
-            var (config, runner) = MakeConfig([], action);
+            var (runner, actionRunner) = MakeRunner([], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
         }
@@ -27,11 +27,11 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsUntaggedAction_WhenMachineHasTags()
         {
             var action = new TestActionSpec();
-            var (config, runner) = MakeConfig(["personal"], action);
+            var (runner, actionRunner) = MakeRunner(["personal"], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
         }
@@ -40,11 +40,11 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsTaggedAction_WhenMachineTagMatches()
         {
             var action = new TestActionSpec { Tags = ["personal"] };
-            var (config, runner) = MakeConfig(["personal"], action);
+            var (runner, actionRunner) = MakeRunner(["personal"], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
         }
@@ -53,11 +53,11 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_SkipsTaggedAction_WhenNoMachineTags()
         {
             var action = new TestActionSpec { Tags = ["personal"] };
-            var (config, runner) = MakeConfig([], action);
+            var (runner, actionRunner) = MakeRunner([], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(
                     It.IsAny<ICnctActionSpec>(),
                     It.IsAny<ILogger>(),
@@ -69,11 +69,11 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_SkipsTaggedAction_WhenMachineTagsDoNotMatch()
         {
             var action = new TestActionSpec { Tags = ["personal"] };
-            var (config, runner) = MakeConfig(["work"], action);
+            var (runner, actionRunner) = MakeRunner(["work"], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(
                     It.IsAny<ICnctActionSpec>(),
                     It.IsAny<ILogger>(),
@@ -85,11 +85,11 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsTaggedAction_CaseInsensitiveMatch()
         {
             var action = new TestActionSpec { Tags = ["Personal"] };
-            var (config, runner) = MakeConfig(["personal"], action);
+            var (runner, actionRunner) = MakeRunner(["personal"], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
         }
@@ -98,11 +98,11 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsTaggedAction_WhenAnyTagMatches()
         {
             var action = new TestActionSpec { Tags = ["personal", "home"] };
-            var (config, runner) = MakeConfig(["work", "home"], action);
+            var (runner, actionRunner) = MakeRunner(["work", "home"], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
         }
@@ -112,16 +112,16 @@ namespace Cnct.Core.Tests
         {
             var untaggedAction = new TestActionSpec();
             var taggedAction = new TestActionSpec { Tags = ["personal"] };
-            var (config, runner) = MakeConfig(
+            var (runner, actionRunner) = MakeRunner(
                 [], untaggedAction, taggedAction);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(
                     untaggedAction, It.IsAny<ILogger>(), "/"),
                 Times.Once);
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(
                     taggedAction, It.IsAny<ILogger>(), It.IsAny<string>()),
                 Times.Never);
@@ -131,18 +131,12 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_LogsStartAndFinish_WithDisplayText()
         {
             var logger = new Mock<ILogger>();
-            var runner = new Mock<IActionRunner>();
+            var actionRunner = new Mock<IActionRunner>();
             var action = new TestActionSpec();
-            var config = new CnctConfig
-            {
-                Logger = logger.Object,
-                Runner = runner.Object,
-                ConfigRootDirectory = "/",
-                MachineTags = [],
-                Actions = [action],
-            };
+            var config = new CnctConfig { Actions = [action] };
+            var runner = new CnctRunner(config, logger.Object, "/", [], actionRunner.Object);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
             logger.Verify(l => l.LogStart("test"), Times.Once);
             logger.Verify(
@@ -154,18 +148,12 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_UsesLabel_WhenLabelIsSet()
         {
             var logger = new Mock<ILogger>();
-            var runner = new Mock<IActionRunner>();
+            var actionRunner = new Mock<IActionRunner>();
             var action = new TestActionSpec { Label = "my custom label" };
-            var config = new CnctConfig
-            {
-                Logger = logger.Object,
-                Runner = runner.Object,
-                ConfigRootDirectory = "/",
-                MachineTags = [],
-                Actions = [action],
-            };
+            var config = new CnctConfig { Actions = [action] };
+            var runner = new CnctRunner(config, logger.Object, "/", [], actionRunner.Object);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
             logger.Verify(l => l.LogStart("test: my custom label"), Times.Once);
             logger.Verify(
@@ -177,18 +165,12 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_UsesGetDisplayText_WhenLabelIsNotSet()
         {
             var logger = new Mock<ILogger>();
-            var runner = new Mock<IActionRunner>();
+            var actionRunner = new Mock<IActionRunner>();
             var action = new TestActionSpec();
-            var config = new CnctConfig
-            {
-                Logger = logger.Object,
-                Runner = runner.Object,
-                ConfigRootDirectory = "/",
-                MachineTags = [],
-                Actions = [action],
-            };
+            var config = new CnctConfig { Actions = [action] };
+            var runner = new CnctRunner(config, logger.Object, "/", [], actionRunner.Object);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
             logger.Verify(l => l.LogStart("test"), Times.Once);
         }
@@ -197,7 +179,7 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_SkipsAction_WhenOsDoesNotMatch()
         {
             var logger = new Mock<ILogger>();
-            var runner = new Mock<IActionRunner>();
+            var actionRunner = new Mock<IActionRunner>();
             var nonCurrentPlatform = Platform.CurrentPlatform == PlatformType.Windows
                 ? PlatformType.Linux
                 : PlatformType.Windows;
@@ -205,18 +187,12 @@ namespace Cnct.Core.Tests
             {
                 PlatformType = [nonCurrentPlatform],
             };
-            var config = new CnctConfig
-            {
-                Logger = logger.Object,
-                Runner = runner.Object,
-                ConfigRootDirectory = "/",
-                MachineTags = [],
-                Actions = [action],
-            };
+            var config = new CnctConfig { Actions = [action] };
+            var runner = new CnctRunner(config, logger.Object, "/", [], actionRunner.Object);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(
                     It.IsAny<ICnctActionSpec>(),
                     It.IsAny<ILogger>(),
@@ -242,11 +218,11 @@ namespace Cnct.Core.Tests
             {
                 PlatformType = [Platform.CurrentPlatform],
             };
-            var (config, runner) = MakeConfig([], action);
+            var (runner, actionRunner) = MakeRunner([], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
         }
@@ -255,31 +231,26 @@ namespace Cnct.Core.Tests
         public async Task ExecuteAsync_RunsAction_WhenOsNotSpecified()
         {
             var action = new TestActionSpec();
-            var (config, runner) = MakeConfig([], action);
+            var (runner, actionRunner) = MakeRunner([], action);
 
-            await config.ExecuteAsync();
+            await runner.ExecuteAsync();
 
-            runner.Verify(
+            actionRunner.Verify(
                 r => r.ExecuteAsync(action, It.IsAny<ILogger>(), "/"),
                 Times.Once);
             Assert.Null(action.PlatformType);
         }
 
-        private static (CnctConfig Config, Mock<IActionRunner> Runner) MakeConfig(
+        private static (CnctRunner Runner, Mock<IActionRunner> ActionRunner) MakeRunner(
             IReadOnlyCollection<string> machineTags,
             params ICnctActionSpec[] actions)
         {
-            var runner = new Mock<IActionRunner>();
-            var config = new CnctConfig
-            {
-                Logger = Mock.Of<ILogger>(),
-                Runner = runner.Object,
-                ConfigRootDirectory = "/",
-                MachineTags = machineTags,
-                Actions = actions,
-            };
+            var actionRunner = new Mock<IActionRunner>();
+            var config = new CnctConfig { Actions = actions };
+            var runner = new CnctRunner(
+                config, Mock.Of<ILogger>(), "/", machineTags, actionRunner.Object);
 
-            return (config, runner);
+            return (runner, actionRunner);
         }
 
         private class TestActionSpec : CnctActionSpecBase

--- a/Cnct/Cnct.Core/CnctCommandLine.cs
+++ b/Cnct/Cnct.Core/CnctCommandLine.cs
@@ -38,13 +38,17 @@ namespace Cnct.Core
         {
             var logger = new ConsoleLogger(new LoggerOptions(quiet, debug));
             var parser = new CnctConfigurationParser(logger);
-            string configFilePath = config?.FullName ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
+            string configFilePath = config?.FullName
+                ?? $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}cnct.json";
 
             CnctConfig cnctConfig = parser.Parse(configFilePath);
-            cnctConfig.MachineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
-            cnctConfig.Runner = new ActionRunner();
+            string configRootDirectory = Path.GetDirectoryName(Path.GetFullPath(configFilePath));
+            IReadOnlyCollection<string> machineTags = (await new MachineSettingsLoader().LoadAsync()).Tags;
 
-            ConfigValidationResult validation = cnctConfig.Validate();
+            var runner = new CnctRunner(
+                cnctConfig, logger, configRootDirectory, machineTags, new ActionRunner());
+
+            ConfigValidationResult validation = runner.Validate();
             if (validate)
             {
                 Console.WriteLine(validation.ToJson());
@@ -61,7 +65,7 @@ namespace Cnct.Core
                 return 1;
             }
 
-            bool result = await cnctConfig.ExecuteAsync();
+            bool result = await runner.ExecuteAsync();
 
             return result ? 0 : 1;
         }

--- a/Cnct/Cnct.Core/CnctRunner.cs
+++ b/Cnct/Cnct.Core/CnctRunner.cs
@@ -1,0 +1,95 @@
+using Cnct.Core.Configuration;
+using Cnct.Core.Tasks;
+using Cnct.Core.Validation;
+
+namespace Cnct.Core
+{
+    public class CnctRunner
+    {
+        private readonly CnctConfig config;
+        private readonly ILogger logger;
+        private readonly string configRootDirectory;
+        private readonly IReadOnlyCollection<string> machineTags;
+        private readonly IActionRunner runner;
+
+        public CnctRunner(
+            CnctConfig config,
+            ILogger logger,
+            string configRootDirectory,
+            IReadOnlyCollection<string> machineTags,
+            IActionRunner runner)
+        {
+            this.config = config;
+            this.logger = logger;
+            this.configRootDirectory = configRootDirectory;
+            this.machineTags = machineTags;
+            this.runner = runner;
+        }
+
+        public ConfigValidationResult Validate()
+        {
+            if (this.config.Actions == null || this.config.Actions.Length == 0)
+            {
+                return new ConfigValidationResult(new[]
+                {
+                    new ValidationIssue(
+                        ValidationSeverity.Error,
+                        "config",
+                        null,
+                        "The configuration must contain at least one action."),
+                });
+            }
+
+            var issues = new List<ValidationIssue>();
+            var context = new CnctContext(this.configRootDirectory, this.machineTags);
+            foreach (var action in this.config.Actions.Where(a => a != null))
+            {
+                issues.AddRange(action.Validate(context));
+            }
+
+            return new ConfigValidationResult(issues);
+        }
+
+        public async Task<bool> ExecuteAsync()
+        {
+            foreach (var action in this.config.Actions.Where(a => a != null))
+            {
+                if (action.Tags.Any()
+                    && !action.Tags.Any(t => this.machineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                {
+                    this.logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
+                    continue;
+                }
+
+                if (!action.ShouldExecuteOnCurrentPlatform())
+                {
+                    this.logger.LogVerbose(
+                        $"Skipping action '{action.ActionType}': not applicable to current OS.");
+                    continue;
+                }
+
+                string displayText = action.GetDisplayText();
+
+                try
+                {
+                    var start = DateTimeOffset.Now;
+                    this.logger.LogStart(displayText);
+
+                    await this.runner.ExecuteAsync(
+                        action, new IndentedLogger(this.logger), this.configRootDirectory);
+
+                    var end = DateTimeOffset.Now;
+                    var elapsed = end - start;
+                    this.logger.LogFinish($"{displayText} ({elapsed.TotalSeconds:F1}s)");
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogError($"Task of type '{action.ActionType}' failed.", ex);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Cnct/Cnct.Core/Configuration/CnctConfig.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfig.cs
@@ -1,87 +1,8 @@
-using Cnct.Core.Tasks;
-using Cnct.Core.Validation;
-
 namespace Cnct.Core.Configuration
 {
     public class CnctConfig
     {
-        [JsonIgnore]
-        public ILogger Logger { get; set; }
-
-        [JsonIgnore]
-        public string ConfigRootDirectory { get; set; }
-
-        [JsonIgnore]
-        public IReadOnlyCollection<string> MachineTags { get; set; } = [];
-
-        [JsonIgnore]
-        public IActionRunner Runner { get; set; } = new ActionRunner();
-
         [JsonProperty(ItemConverterType = typeof(CnctActionConverter))]
         public ICnctActionSpec[] Actions { get; set; }
-
-        public ConfigValidationResult Validate()
-        {
-            if (this.Actions == null || this.Actions.Length == 0)
-            {
-                return new ConfigValidationResult(new[]
-                {
-                    new ValidationIssue(
-                        ValidationSeverity.Error,
-                        "config",
-                        null,
-                        "The configuration must contain at least one action."),
-                });
-            }
-
-            var issues = new List<ValidationIssue>();
-            var context = new CnctContext(this.ConfigRootDirectory, this.MachineTags);
-            foreach (var action in this.Actions.Where(a => a != null))
-            {
-                issues.AddRange(action.Validate(context));
-            }
-
-            return new ConfigValidationResult(issues);
-        }
-
-        public async Task<bool> ExecuteAsync()
-        {
-            foreach (var action in this.Actions.Where(a => a != null))
-            {
-                if (action.Tags.Any()
-                    && !action.Tags.Any(t => this.MachineTags.Contains(t, StringComparer.OrdinalIgnoreCase)))
-                {
-                    this.Logger.LogVerbose($"Skipping action '{action.ActionType}': no matching machine tag.");
-                    continue;
-                }
-
-                if (!action.ShouldExecuteOnCurrentPlatform())
-                {
-                    this.Logger.LogVerbose($"Skipping action '{action.ActionType}': not applicable to current OS.");
-                    continue;
-                }
-
-                string displayText = action.GetDisplayText();
-
-                try
-                {
-                    var start = DateTimeOffset.Now;
-                    this.Logger.LogStart(displayText);
-
-                    await this.Runner.ExecuteAsync(action, new IndentedLogger(this.Logger), this.ConfigRootDirectory);
-
-                    var end = DateTimeOffset.Now;
-                    var elapsed = end - start;
-                    this.Logger.LogFinish($"{displayText} ({elapsed.TotalSeconds:F1}s)");
-                }
-                catch (Exception ex)
-                {
-                    this.Logger.LogError($"Task of type '{action.ActionType}' failed.", ex);
-                    return false;
-                }
-            }
-
-            return true;
-        }
     }
 }

--- a/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
+++ b/Cnct/Cnct.Core/Configuration/CnctConfigurationParser.cs
@@ -37,11 +37,7 @@ namespace Cnct.Core.Configuration
             try
             {
                 string json = this.fileSystem.File.ReadAllText(configFile);
-                CnctConfig config = JsonConvert.DeserializeObject<CnctConfig>(json);
-                config.Logger = this.logger;
-                config.ConfigRootDirectory = this.fileSystem.Path.GetDirectoryName(configFile);
-
-                return config;
+                return JsonConvert.DeserializeObject<CnctConfig>(json);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

Separate the JSON data model from the runtime execution logic in `CnctConfig`.

### Before
`CnctConfig` mixed three concerns:
- JSON data model (`Actions` array)
- Runtime context (`Logger`, `ConfigRootDirectory`, `MachineTags`, `Runner` — all `[JsonIgnore]`)
- Business logic (`Validate()`, `ExecuteAsync()`)

### After
- **`CnctConfig`** — pure JSON data model with only the `Actions` property
- **`CnctRunner`** — new class that takes config + runtime dependencies via constructor, owns `Validate()` and `ExecuteAsync()`

### Changes
- `CnctConfig`: removed all `[JsonIgnore]` properties and business logic methods
- `CnctRunner`: new file at `Cnct.Core/CnctRunner.cs`
- `CnctConfigurationParser`: simplified — returns pure `CnctConfig` without setting runtime properties
- `CnctCommandLine`: constructs `CnctRunner` with parsed config + runtime deps
- Tests: renamed `CnctConfigTagFilteringTests` to `CnctRunnerTests`, updated to construct `CnctRunner`

All 109 tests pass, 0 warnings, 0 errors.
